### PR TITLE
Make nvl return the replacement type if no type is available in operand

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
@@ -91,7 +91,7 @@ public class NativeFunctionsVisitor extends VTLBaseVisitor<VTLExpression> {
         VTLExpression finalNullable = changeExpressionType(nullable, replacement);
 
         checkArgument(
-                nullable.getVTLType().equals(replacement.getVTLType()),
+                finalNullable.getVTLType().equals(replacement.getVTLType()),
                 "%s and %s must be of the same type",
                 nullableCtx.getText(),
                 replacementCtx.getText()

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
@@ -88,7 +88,8 @@ public class NativeFunctionsVisitor extends VTLBaseVisitor<VTLExpression> {
         VTLExpression nullable = expressionVisitor.visit(nullableCtx);
         VTLExpression replacement = expressionVisitor.visit(replacementCtx);
 
-        VTLExpression finalNullable = changeExpressionType(nullable, replacement);
+        // If it is a null literal (type unknown) make it the type of replacement.
+        VTLExpression finalNullable = coerceNullLiteralType(nullable, replacement);
 
         checkArgument(
                 finalNullable.getVTLType().equals(replacement.getVTLType()),
@@ -106,8 +107,7 @@ public class NativeFunctionsVisitor extends VTLBaseVisitor<VTLExpression> {
     }
 
     @VisibleForTesting
-    static VTLExpression changeExpressionType(VTLExpression expression, VTLTyped replacement) {
-        // null literal have a "flexible type"; it takes the type that was expected.
+    static VTLExpression coerceNullLiteralType(VTLExpression expression, VTLTyped replacement) {
         if (expression.getVTLType().equals(VTLObject.class)) {
             return new VTLExpression() {
                 @Override

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitorTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitorTest.java
@@ -22,6 +22,9 @@ package no.ssb.vtl.script.visitors.functions;
 
 import no.ssb.vtl.model.VTLExpression;
 import no.ssb.vtl.model.VTLInteger;
+import no.ssb.vtl.model.VTLObject;
+import no.ssb.vtl.model.VTLString;
+import no.ssb.vtl.model.VTLTyped;
 import no.ssb.vtl.parser.VTLLexer;
 import no.ssb.vtl.parser.VTLParser;
 import no.ssb.vtl.script.visitors.ExpressionVisitor;
@@ -31,6 +34,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.script.Bindings;
 import javax.script.SimpleBindings;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,5 +139,32 @@ public class NativeFunctionsVisitorTest {
         VTLParser parser = parse("trunc(1.566, 1)");
         VTLExpression<?> result = visitor.visit(parser.expression());
         assertThat(result.resolve(null).get()).isEqualTo(1.5);
+    }
+
+    @Test
+    public void testNvlWithNull() throws Exception {
+
+        VTLExpression expression = new VTLExpression<VTLObject>() {
+
+            @Override
+            public Class getVTLType() {
+                return VTLObject.class;
+            }
+
+            @Override
+            public VTLObject resolve(Bindings bindings) {
+                return VTLObject.NULL;
+            }
+        };
+        VTLTyped<VTLString> replacement = new VTLTyped<VTLString>() {
+            @Override
+            public Class<VTLString> getVTLType() {
+                return VTLString.class;
+            }
+        };
+
+        VTLExpression result = NativeFunctionsVisitor.coerceNullLiteralType(expression, replacement);
+
+        assertThat(result.getVTLType()).isEqualTo(VTLString.class);
     }
 }


### PR DESCRIPTION
The nvl function checks that the type of the two operand are the same; nvl(value:expr, replacement:expr) will only work if value:expr and replacement:expr are of the same type, but in the expression nvl(null, "string" || "string") the type of null is unknown.

I fixed this by using the type of the replacement expression if the value is a null literal.