### PR TITLE
Exception handling PoC

### DIFF
--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLObject.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLObject.java
@@ -50,6 +50,8 @@ public abstract class VTLObject<V> implements Supplier<V>, Comparable<Object> {
      * </pre></code>
      */
     public static VTLObject of(Object o) {
+        if (o == null)
+            return VTLObject.NULL;
         if (o instanceof VTLObject)
             return (VTLObject) o;
         if (o instanceof String)

--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLObject.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLObject.java
@@ -50,8 +50,6 @@ public abstract class VTLObject<V> implements Supplier<V>, Comparable<Object> {
      * </pre></code>
      */
     public static VTLObject of(Object o) {
-        if (o == null)
-            return VTLObject.NULL;
         if (o instanceof VTLObject)
             return (VTLObject) o;
         if (o instanceof String)

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
@@ -20,34 +20,15 @@ package no.ssb.vtl.script;
  * =========================LICENSE_END==================================
  */
 
-/*-
- * #%L
- * java-vtl-script
- * %%
- * Copyright (C) 2016 Hadrien Kohl
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
-
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.connectors.Connector;
 import no.ssb.vtl.parser.VTLLexer;
 import no.ssb.vtl.parser.VTLParser;
-import no.ssb.vtl.script.error.SyntaxException;
-import no.ssb.vtl.script.error.WrappedException;
+import no.ssb.vtl.script.error.ContextualRuntimeException;
+import no.ssb.vtl.script.error.VTLCompileException;
+import no.ssb.vtl.script.error.VTLScriptException;
 import no.ssb.vtl.script.visitors.AssignmentVisitor;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -55,7 +36,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.Token;
 
 import javax.script.AbstractScriptEngine;
 import javax.script.Bindings;
@@ -67,7 +48,9 @@ import javax.script.SimpleBindings;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.TimeZone;
+import java.util.function.Consumer;
 
 /**
  * A VTL {@link ScriptEngine} implementation.
@@ -134,89 +117,80 @@ public class VTLScriptEngine extends AbstractScriptEngine {
         return eval(new StringReader(script), context);
     }
 
+    public VTLParser.StartContext compile(Reader reader, Consumer<VTLScriptException> errorConsumer) throws IOException {
+        // TODO: Change to CharStreams.fromString() when #1977 makes it to release.
+        VTLLexer lexer = new VTLLexer(new ANTLRInputStream(reader));
+        VTLParser parser = new VTLParser(new CommonTokenStream(lexer));
+
+        lexer.removeErrorListeners();
+        parser.removeErrorListeners();
+
+        BaseErrorListener errorListener = new BaseErrorListener() {
+            @Override
+            public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int startLine, int startColumn, String msg, RecognitionException e) {
+                VTLScriptException vtlScriptException;
+                // Use the context from the RecognitionException if available.
+                if (e != null) {
+                    vtlScriptException = new VTLScriptException(msg, (ParserRuleContext) e.getCtx());
+                } else {
+                    int stopColumn = startColumn;
+                    if (offendingSymbol instanceof Token) {
+                        Token symbol = (Token) offendingSymbol;
+                        int start = symbol.getStartIndex();
+                        int stop = symbol.getStopIndex();
+                        if (start >= 0 && stop >= 0) {
+                            stopColumn = startColumn + (stop - start) + 1;
+                        }
+                        vtlScriptException = new VTLScriptException(msg, startLine, startColumn, startLine, stopColumn);
+                    } else {
+                        vtlScriptException = new VTLScriptException(msg, startLine, startColumn);
+                    }
+                }
+                errorConsumer.accept(vtlScriptException);
+            }
+        };
+
+        lexer.addErrorListener(errorListener);
+        parser.addErrorListener(errorListener);
+
+        return parser.start();
+    }
+
     @Override
     public Object eval(Reader reader, ScriptContext context) throws ScriptException {
-        /*
-            Until compilation is done, this is the main method that allows
-            VTL execution.
-            Exceptions' hierarchy is as follow:
-                - ScriptException
-                    - CompilationException
-                        - SyntaxException
-                        - TypeException
-                        - ConstraintException
-                    - ValidationException
-                    - VTLRuntimeException
-            The WrappedScriptException is used to report errors that are not originating
-            from the VTL Parser.
-         */
         try {
-            VTLLexer lexer = new VTLLexer(new ANTLRInputStream(reader));
-            VTLParser parser = new VTLParser(new CommonTokenStream(lexer));
-
-            lexer.removeErrorListeners();
-            parser.removeErrorListeners();
-
-            BaseErrorListener errorListener = new BaseErrorListener() {
-                @Override
-                public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int column, String msg, RecognitionException e) {
-                    WrappedException wrappedException;
-                    if (e instanceof WrappedException) {
-                        wrappedException = (WrappedException) e;
-                    } else {
-                        wrappedException = new WrappedException(
-                                msg,
-                                recognizer,
-                                e != null ? e.getInputStream() : null,
-                                e != null ? (ParserRuleContext) e.getCtx() : null,
-                                new SyntaxException(
-                                        msg, null, line, column, "VTL-0199"
-                                )
-                        );
-                    }
-                    wrappedException.setLine(line);
-                    wrappedException.setColumn(column);
-                    throw new ParseCancellationException(msg, wrappedException);
-                }
-            };
-            lexer.addErrorListener(errorListener);
-            parser.addErrorListener(errorListener);
-
-            VTLParser.StartContext start = parser.start();
-
-            // Run loop.
-            AssignmentVisitor assignmentVisitor = new AssignmentVisitor(context, connectors);
-            Object last = null;
-            for (VTLParser.StatementContext statementContext : start.statement()) {
-                last = assignmentVisitor.visit(statementContext);
-            }
-            return last;
-
-        } catch (ParseCancellationException pce) {
-            if (pce.getCause() instanceof WrappedException) {
-                WrappedException cause = (WrappedException) pce.getCause();
-
-                if (cause.getCause() instanceof ScriptException) {
-                    throw ((ScriptException) cause.getCause());
-                } else {
-                    throw new ScriptException(
-                            pce.getMessage(),
-                            null,
-                            cause.getLineNumber(),
-                            cause.getColumnNumber()
-                    );
-                }
-
+            ArrayList<VTLScriptException> errors = Lists.newArrayList();
+            VTLParser.StartContext start = compile(reader, errors::add);
+            Object returnValue = run(start, errors::add);
+            if (!errors.isEmpty()) {
+                throw new VTLCompileException(errors);
             } else {
-                if (pce.getCause() != null) {
-                    throw new ScriptException(pce.getCause().getMessage());
+                return returnValue;
+            }
+        } catch (IOException | RuntimeException unknownException) {
+            throw new ScriptException(unknownException);
+        }
+    }
+
+    /**
+     * Run loop
+     */
+    private Object run(VTLParser.StartContext start, Consumer<VTLScriptException> errorConsumer) throws VTLScriptException {
+        AssignmentVisitor assignmentVisitor = new AssignmentVisitor(context, connectors);
+        Object last = null;
+        for (VTLParser.StatementContext statementContext : start.statement()) {
+            try {
+                last = assignmentVisitor.visit(statementContext);
+            } catch (ContextualRuntimeException cre) {
+                ParserRuleContext ctx = cre.getContext();
+                if (cre.getCause() != null) {
+                    errorConsumer.accept(new VTLScriptException((Exception) cre.getCause(), ctx));
                 } else {
-                    throw new ScriptException(pce.getMessage());
+                    errorConsumer.accept(new VTLScriptException(cre.getMessage(), ctx));
                 }
             }
-        } catch (IOException | RuntimeException ioe) {
-            throw new ScriptException(ioe);
         }
+        return last;
     }
 
     @Override

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
@@ -115,7 +115,7 @@ public class VTLScriptEngine extends AbstractScriptEngine {
         return eval(new StringReader(script), context);
     }
 
-    public VTLParser.StartContext compile(Reader reader, Consumer<VTLScriptException> errorConsumer) throws IOException {
+    public VTLParser.StartContext parse(Reader reader, Consumer<VTLScriptException> errorConsumer) throws IOException {
         // TODO: Change to CharStreams.fromString() when #1977 makes it to release.
         VTLLexer lexer = new VTLLexer(new ANTLRInputStream(reader));
         VTLParser parser = new VTLParser(new CommonTokenStream(lexer));
@@ -135,7 +135,7 @@ public class VTLScriptEngine extends AbstractScriptEngine {
     public Object eval(Reader reader, ScriptContext context) throws ScriptException {
         try {
             ArrayList<VTLScriptException> errors = Lists.newArrayList();
-            VTLParser.StartContext start = compile(reader, errors::add);
+            VTLParser.StartContext start = parse(reader, errors::add);
             Object returnValue = run(start, errors::add, context);
             if (!errors.isEmpty()) {
                 throw new VTLCompileException(errors);

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
@@ -136,7 +136,7 @@ public class VTLScriptEngine extends AbstractScriptEngine {
         try {
             ArrayList<VTLScriptException> errors = Lists.newArrayList();
             VTLParser.StartContext start = compile(reader, errors::add);
-            Object returnValue = run(start, errors::add);
+            Object returnValue = run(start, errors::add, context);
             if (!errors.isEmpty()) {
                 throw new VTLCompileException(errors);
             } else {
@@ -150,7 +150,7 @@ public class VTLScriptEngine extends AbstractScriptEngine {
     /**
      * Run loop
      */
-    private Object run(VTLParser.StartContext start, Consumer<VTLScriptException> errorConsumer) throws VTLScriptException {
+    private Object run(VTLParser.StartContext start, Consumer<VTLScriptException> errorConsumer, ScriptContext context) throws VTLScriptException {
         AssignmentVisitor assignmentVisitor = new AssignmentVisitor(context, connectors);
         Object last = null;
         for (VTLParser.StatementContext statementContext : start.statement()) {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ContextualRuntimeException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ContextualRuntimeException.java
@@ -1,0 +1,59 @@
+package no.ssb.vtl.script.error;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A {@link RuntimeException} that contains the context in which it happened.
+ */
+public class ContextualRuntimeException extends RuntimeException {
+
+    private final ParserRuleContext context;
+
+    public ContextualRuntimeException(ParserRuleContext context) {
+        this.context = checkNotNull(context);
+    }
+
+    public ContextualRuntimeException(String message, ParserRuleContext context) {
+        super(message);
+        this.context = checkNotNull(context);
+    }
+
+    public ContextualRuntimeException(String message, Throwable cause, ParserRuleContext context) {
+        super(message, cause);
+        this.context = checkNotNull(context);
+    }
+
+    public ContextualRuntimeException(Throwable cause, ParserRuleContext context) {
+        super(cause.getMessage(), cause);
+        this.context = checkNotNull(context);
+    }
+
+    public ContextualRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, ParserRuleContext context) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.context = checkNotNull(context);
+    }
+
+    public ParserRuleContext getContext() {
+        return context;
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ContextualRuntimeException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ContextualRuntimeException.java
@@ -21,6 +21,7 @@ package no.ssb.vtl.script.error;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 /**
  * A {@link RuntimeException} that contains the context in which it happened.
@@ -51,6 +52,18 @@ public class ContextualRuntimeException extends RuntimeException {
     public ContextualRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, ParserRuleContext context) {
         super(message, cause, enableSuppression, writableStackTrace);
         this.context = checkNotNull(context);
+    }
+
+    public static void checkArgument(ParserRuleContext context, boolean expression) throws ContextualRuntimeException {
+        if (!expression) {
+            throw new ContextualRuntimeException(context);
+        }
+    }
+
+    public static void checkArgument(ParserRuleContext context, boolean expression, String template, Object... arguments) throws ContextualRuntimeException {
+        if (!expression) {
+            throw new ContextualRuntimeException(format(template, arguments), context);
+        }
     }
 
     public ParserRuleContext getContext() {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/PositionableError.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/PositionableError.java
@@ -23,13 +23,15 @@ package no.ssb.vtl.script.error;
 /**
  * Mark the exception as positionable.
  */
+@Deprecated
 public interface PositionableError {
-
-    void setLine(int line);
-
-    void setColumn(int column);
 
     int getLineNumber();
 
     int getColumnNumber();
+
+    int getStartLine();
+    int getStopLine();
+    int getStartColumn();
+    int getStopColumn();
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLCompileException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLCompileException.java
@@ -1,0 +1,49 @@
+package no.ssb.vtl.script.error;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.google.common.collect.Lists;
+
+import javax.script.ScriptException;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class VTLCompileException extends ScriptException {
+
+    public List<VTLScriptException> getErrors() {
+        return errors;
+    }
+
+    private List<VTLScriptException> errors = Lists.newArrayList();
+
+    public VTLCompileException(List<VTLScriptException> errors) {
+        super("compilation errors");
+        this.errors = checkNotNull(errors);
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder message = new StringBuilder(super.getMessage());
+        for (VTLScriptException exception : getErrors()) {
+            message.append("\n\t - ").append(exception.getMessage());
+        }
+        return message.toString();
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLErrorCodeUtil.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLErrorCodeUtil.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Utility class for error codes.
  */
+@Deprecated
 public class VTLErrorCodeUtil {
 
     public static String checkVTLCode(String vtlCode, String prefix) {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLRuntimeException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLRuntimeException.java
@@ -29,6 +29,7 @@ import static no.ssb.vtl.script.error.VTLErrorCodeUtil.checkVTLCode;
 /**
  * Thrown when the VTL execution failed at runtime.
  */
+@Deprecated
 public class VTLRuntimeException extends RuntimeException implements VTLThrowable {
 
     private static final long serialVersionUID = 7253953869019949964L;

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLScriptException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/VTLScriptException.java
@@ -1,0 +1,124 @@
+package no.ssb.vtl.script.error;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import javax.script.ScriptException;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Subclass of {@link ScriptException} that exposes start and end positions.
+ */
+public class VTLScriptException extends ScriptException implements PositionableError {
+
+    private static final String UNKNOWN_SOURCE_NAME = "<unknown>";
+    private String fileName = UNKNOWN_SOURCE_NAME;
+
+    private int startLine = -1;
+    private int startColumn = -1;
+
+    private int stopLine = -1;
+    private int stopColumn = -1;
+
+    public VTLScriptException(Exception e, ParserRuleContext ctx) {
+        super(e.getMessage());
+        extractPositionFromContext(ctx);
+    }
+
+    public VTLScriptException(String message, ParserRuleContext ctx) {
+        super(message);
+        extractPositionFromContext(ctx);
+    }
+
+    public VTLScriptException(String msg, int line, int column) {
+        super(msg);
+        this.startLine = line;
+        this.startColumn = column;
+    }
+
+    public VTLScriptException(String msg, int startLine, int startColumn, int stopLine, int stopColumn) {
+        super(msg);
+
+        this.startColumn = startColumn;
+        this.startLine = startLine;
+
+        this.stopColumn = stopColumn;
+        this.stopLine = stopLine;
+    }
+
+
+    private void extractPositionFromContext(ParserRuleContext ctx) {
+        checkNotNull(ctx);
+        startLine = ctx.getStart().getLine();
+        startColumn = ctx.getStart().getCharPositionInLine();
+        stopLine = ctx.getStop().getLine();
+        stopColumn = ctx.getStop().getCharPositionInLine();
+    }
+
+    @Override
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = Optional.ofNullable(fileName).orElse(UNKNOWN_SOURCE_NAME);
+    }
+
+    @Override
+    public String getMessage() {
+        String message = super.getMessage();
+        message += " in " + getFileName();
+        message += " at line number " + getLineNumber();
+        message += " at column number " + getColumnNumber();
+        return message;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return getStartLine();
+    }
+
+    @Override
+    public int getColumnNumber() {
+        return getStartColumn();
+    }
+
+    @Override
+    public int getStartLine() {
+        return startLine;
+    }
+
+    @Override
+    public int getStopLine() {
+        return stopLine;
+    }
+
+    @Override
+    public int getStartColumn() {
+        return startColumn;
+    }
+
+    @Override
+    public int getStopColumn() {
+        return stopColumn;
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ValidationException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/ValidationException.java
@@ -26,6 +26,7 @@ import javax.script.ScriptException;
  * The validation exception is thrown when a validation fails in the
  * VTL script.
  */
+@Deprecated
 public class ValidationException extends ScriptException {
     public ValidationException(String s) {
         super(s);

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/error/WrappedException.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/error/WrappedException.java
@@ -30,6 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Created by hadrien on 13/12/2016.
  */
+@Deprecated
 public class WrappedException extends RecognitionException implements PositionableError {
 
     private final Exception cause;
@@ -51,12 +52,10 @@ public class WrappedException extends RecognitionException implements Positionab
         return cause;
     }
 
-    @Override
     public void setLine(int line) {
         this.line = line;
     }
 
-    @Override
     public void setColumn(int column) {
         this.column = column;
     }
@@ -69,5 +68,25 @@ public class WrappedException extends RecognitionException implements Positionab
     @Override
     public int getColumnNumber() {
         return this.column;
+    }
+
+    @Override
+    public int getStartLine() {
+        return 0;
+    }
+
+    @Override
+    public int getStopLine() {
+        return 0;
+    }
+
+    @Override
+    public int getStartColumn() {
+        return 0;
+    }
+
+    @Override
+    public int getStopColumn() {
+        return 0;
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/support/SyntaxErrorListener.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/support/SyntaxErrorListener.java
@@ -1,0 +1,66 @@
+package no.ssb.vtl.script.support;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import no.ssb.vtl.script.error.VTLScriptException;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An error listener that converts syntax errors to {@link no.ssb.vtl.script.error.VTLScriptException}
+ * and pass them to a consumer.
+ */
+public class SyntaxErrorListener extends BaseErrorListener {
+
+    private final Consumer<VTLScriptException> errorConsumer;
+
+    public SyntaxErrorListener(Consumer<VTLScriptException> errorConsumer) {
+        this.errorConsumer = checkNotNull(errorConsumer);
+    }
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int startLine, int startColumn, String msg, RecognitionException e) {
+        VTLScriptException vtlScriptException;
+        // Use the context from the RecognitionException if available.
+        if (e != null && e.getCtx() != null) {
+            vtlScriptException = new VTLScriptException(msg, (ParserRuleContext) e.getCtx());
+        } else {
+            int stopColumn = startColumn;
+            if (offendingSymbol instanceof Token) {
+                Token symbol = (Token) offendingSymbol;
+                int start = symbol.getStartIndex();
+                int stop = symbol.getStopIndex();
+                if (start >= 0 && stop >= 0) {
+                    stopColumn = startColumn + (stop - start) + 1;
+                }
+                vtlScriptException = new VTLScriptException(msg, startLine, startColumn, startLine, stopColumn);
+            } else {
+                vtlScriptException = new VTLScriptException(msg, startLine, startColumn);
+            }
+        }
+        errorConsumer.accept(vtlScriptException);
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AssignmentVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AssignmentVisitor.java
@@ -26,6 +26,7 @@ import no.ssb.vtl.model.VTLExpression;
 import no.ssb.vtl.model.VTLObject;
 import no.ssb.vtl.parser.VTLBaseVisitor;
 import no.ssb.vtl.parser.VTLParser;
+import no.ssb.vtl.script.error.ContextualRuntimeException;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -73,7 +74,11 @@ public class AssignmentVisitor extends VTLBaseVisitor<Object> {
             value = visit(ctx.datasetExpression());
         } else {
             VTLExpression expression = expressionVisitor.visit(ctx.expression());
-            value = expression.resolve(bindings).get();
+            try {
+                value = expression.resolve(bindings).get();
+            } catch (Exception e) {
+                throw new ContextualRuntimeException(e.getMessage(), ctx);
+            }
         }
         bindings.put(name, value);
         return value;

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/ExpressionVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/ExpressionVisitor.java
@@ -31,6 +31,7 @@ import no.ssb.vtl.model.VTLTyped;
 import no.ssb.vtl.parser.VTLBaseVisitor;
 import no.ssb.vtl.parser.VTLParser;
 import no.ssb.vtl.script.VTLDataset;
+import no.ssb.vtl.script.error.ContextualRuntimeException;
 import no.ssb.vtl.script.error.VTLRuntimeException;
 import no.ssb.vtl.script.functions.FunctionExpression;
 import no.ssb.vtl.script.functions.VTLAddition;
@@ -284,9 +285,9 @@ public class ExpressionVisitor extends VTLBaseVisitor<VTLExpression> {
         if (bindings.containsKey(identifier))
             return identifier;
 
-        throw new VTLRuntimeException(
-                format("undefined variable [%s] (scope [%s])", identifier, bindings),
-                "VTL-101", ctx
+        throw new ContextualRuntimeException(
+                format("undefined variable %s", identifier),
+                ctx
         );
     }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/functions/NativeFunctionsVisitor.java
@@ -143,12 +143,6 @@ public class NativeFunctionsVisitor extends VTLBaseVisitor<VTLExpression> {
                     ), ctx
             );
         }
-//            checkArgument(
-//                    finalNullable.getVTLType().equals(replacement.getVTLType()),
-//                    "%s and %s must be of the same type",
-//                    nullableCtx.getText(),
-//                    replacementCtx.getText()
-//            );
 
         return new FunctionExpression<VTLObject>(new VTLNvl(), finalNullable, replacement) {
             @Override

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLErrorsTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLErrorsTest.java
@@ -1,0 +1,47 @@
+package no.ssb.vtl.script;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import no.ssb.vtl.script.error.VTLCompileException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class VTLErrorsTest {
+
+    @Test
+    public void testErrorRecovery() {
+
+        // @formatter:off
+        String script = "variable := nvl(bla\"error\") // normal syntax error\n" +
+                        "variable := nvl(\"string\", \"\")   // type error\n" +
+                        "variable := round(0)             // missing argument\n";
+        // @formatter:on
+
+        VTLScriptEngine engine = new VTLScriptEngine();
+        assertThatThrownBy(() -> {
+            engine.eval(script);
+        })
+                .as("engine exception")
+                .isInstanceOf(VTLCompileException.class)
+                .hasMessageContaining("undefined variable bla")
+                .hasMessageContaining("missing ','")
+                .hasMessageContaining("missing arguments [decimals]");
+    }
+}

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/support/SyntaxErrorListenerTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/support/SyntaxErrorListenerTest.java
@@ -1,0 +1,91 @@
+package no.ssb.vtl.script.support;
+
+/*
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.google.common.collect.Lists;
+import no.ssb.vtl.script.error.VTLScriptException;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SyntaxErrorListenerTest {
+
+    @Test
+    public void testSyntaxErrorWithoutContext() throws Exception {
+        List<VTLScriptException> errors = Lists.newArrayList();
+        SyntaxErrorListener listener = new SyntaxErrorListener(errors::add);
+        listener.syntaxError(null, null, 123, 321, "vtl error", null);
+
+        assertThat(errors).isNotEmpty();
+        VTLScriptException exception = errors.get(0);
+        assertThat(exception)
+                .hasMessageContaining("vtl error");
+
+        assertThat(exception.getStartLine()).isEqualTo(123);
+        assertThat(exception.getLineNumber()).isEqualTo(123);
+
+        assertThat(exception.getStartColumn()).isEqualTo(321);
+        assertThat(exception.getColumnNumber()).isEqualTo(321);
+
+    }
+
+    @Test
+    public void testSyntaxErrorWithContext() throws Exception {
+        List<VTLScriptException> errors = Lists.newArrayList();
+        SyntaxErrorListener listener = new SyntaxErrorListener(errors::add);
+
+        ParserRuleContext ruleContext = new ParserRuleContext();
+        ruleContext.start = new CommonToken(0, "start") {{
+            setLine(789);
+            setCharPositionInLine(987);
+        }};
+        ruleContext.stop = new CommonToken(1, "stop") {{
+            setLine(456);
+            setCharPositionInLine(654);
+        }};
+
+        RecognitionException recognitionError = new RecognitionException(
+                "recognition error", null, null, ruleContext
+        );
+        listener.syntaxError(null, null, 123, 321, "vtl error", recognitionError);
+
+        assertThat(errors).isNotEmpty();
+        VTLScriptException exception = errors.get(0);
+        assertThat(exception)
+                .hasMessageContaining("vtl error");
+
+        assertThat(exception.getStartLine()).isEqualTo(789);
+        assertThat(exception.getLineNumber()).isEqualTo(789);
+
+        assertThat(exception.getStartColumn()).isEqualTo(987);
+        assertThat(exception.getColumnNumber()).isEqualTo(987);
+
+
+        assertThat(exception.getStopLine()).isEqualTo(456);
+        assertThat(exception.getStopColumn()).isEqualTo(654);
+
+
+
+    }
+}

--- a/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/Application.java
+++ b/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/Application.java
@@ -117,13 +117,6 @@ public class Application {
 
         RestTemplate template = new RestTemplate(schrf);
 
-//        template.getInterceptors().add(
-//                new AuthorizationTokenInterceptor()
-//        );
-
-        //ObjectMapper mapper = new ObjectMapper();
-        // mapper.registerModule(new JavaTimeModule());
-
         template.getMessageConverters().add(
                 0, new DataHttpConverter(mapper)
         );

--- a/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/controllers/ExecutorController.java
+++ b/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/controllers/ExecutorController.java
@@ -26,8 +26,6 @@ import no.ssb.vtl.tools.rest.representations.DatasetRepresentation;
 import no.ssb.vtl.tools.rest.representations.ExecutionRepresentation;
 import no.ssb.vtl.tools.rest.representations.ResultRepresentation;
 import no.ssb.vtl.tools.rest.representations.ThrowableRepresentation;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,6 +39,8 @@ import javax.script.Bindings;
 import javax.script.ScriptException;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Simple execution service that allows executions of a VTL expression
  * and returns the context.
@@ -53,12 +53,11 @@ import java.util.Map;
 @RestController
 public class ExecutorController {
 
-    @Autowired
-    public VTLScriptEngine vtlEngine;
+    private final VTLScriptEngine vtlEngine;
 
-    @Autowired
-    @Qualifier("vtlBindings")
-    public Bindings bindings;
+    public ExecutorController(VTLScriptEngine vtlEngine) {
+        this.vtlEngine = checkNotNull(vtlEngine);
+    }
 
     @ExceptionHandler
     @ResponseStatus()

--- a/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/controllers/UserExecutorController.java
+++ b/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/controllers/UserExecutorController.java
@@ -28,8 +28,6 @@ import no.ssb.vtl.model.VTLObject;
 import no.ssb.vtl.script.VTLScriptEngine;
 import no.ssb.vtl.tools.rest.representations.StructureRepresentation;
 import no.ssb.vtl.tools.rest.representations.ThrowableRepresentation;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -41,12 +39,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.script.Bindings;
-import javax.script.ScriptContext;
 import javax.script.ScriptException;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
 import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @CrossOrigin(origins = "http://localhost:8000/")
 @RequestMapping(
@@ -56,12 +55,13 @@ import java.util.Map;
 @RestController
 public class UserExecutorController {
 
-    @Autowired
-    public VTLScriptEngine vtlEngine;
+    private final VTLScriptEngine engine;
+    private final Bindings bindings;
 
-    @Autowired
-    @Qualifier("vtlBindings")
-    public Bindings bindings;
+    public UserExecutorController(VTLScriptEngine engine, Bindings bindings) {
+        this.engine = checkNotNull(engine);
+        this.bindings = checkNotNull(bindings);
+    }
 
     @ExceptionHandler
     @ResponseStatus()
@@ -74,8 +74,7 @@ public class UserExecutorController {
             method = RequestMethod.POST
     )
     public Collection<String> execute(Reader script) throws IOException, ScriptException {
-        vtlEngine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
-        vtlEngine.eval(script);
+        engine.eval(script, bindings);
         return bindings.keySet();
     }
 

--- a/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/representations/SyntaxErrorRepresentation.java
+++ b/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/representations/SyntaxErrorRepresentation.java
@@ -22,7 +22,6 @@ package no.ssb.vtl.tools.rest.representations;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import no.ssb.vtl.tools.rest.controllers.ValidatorController;
-import org.antlr.v4.runtime.RecognitionException;
 
 /**
  * Json representation of syntax errors.
@@ -38,7 +37,7 @@ public class SyntaxErrorRepresentation {
     private final String message;
     private final ThrowableRepresentation exception;
 
-    public SyntaxErrorRepresentation(Integer startLine, Integer stopLine, Integer startColumn, Integer stopColumn, String message, RecognitionException exception) {
+    public SyntaxErrorRepresentation(Integer startLine, Integer stopLine, Integer startColumn, Integer stopColumn, String message, Exception exception) {
         this.startLine = startLine;
         this.stopLine = stopLine;
         this.startColumn = startColumn;

--- a/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/representations/ThrowableRepresentation.java
+++ b/java-vtl-tools/src/main/java/no/ssb/vtl/tools/rest/representations/ThrowableRepresentation.java
@@ -21,9 +21,7 @@ package no.ssb.vtl.tools.rest.representations;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import com.google.common.base.Throwables;
 
 /**
  * Json representation of a {@link java.lang.Throwable}.
@@ -42,9 +40,7 @@ public class ThrowableRepresentation {
     }
 
     public String getStackTrace() {
-        StringWriter sw = new StringWriter();
-        t.printStackTrace(new PrintWriter(sw));
-        return sw.toString();
+        return Throwables.getStackTraceAsString(t);
     }
 
 }


### PR DESCRIPTION
This PR is in preparation for #40. The goal is to improve the exception handling in the java-script project.

I created a new `ContextualRuntimeException` that contains a reference to the ParserRuleContext we get from ANTLR so that we can give the position of an error to the user. I also added `VTLScriptException` which extends the ScriptException, mainly because the ScriptException constructors are too restricting.

I adjusted `AssignmentVisitor`, `ExpressionVisitor` and `NativeFunctionsVisitor` to use the new exceptions. Take a look at `VTLErrorsTest` for an example of what the result is.