### PR TITLE
Variable expression in sum throws npe

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/AggregationOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/AggregationOperation.java
@@ -63,6 +63,7 @@ public class AggregationOperation extends AbstractUnaryDatasetOperation {
                 if (Number.class.isAssignableFrom(entry.getValue().getType())) {
                     newDataStructure.put(entry);
                 } else {
+                    // TODO: This should be handled in the visitor (before execution)
                     throw new ParseCancellationException(
                             new TypeException(String.format("Cannot aggregate component %s of type %s. It must be numeric", entry.getKey(), entry.getValue().getType()), "VTL-02xx"));
                 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AbstractVariableVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AbstractVariableVisitor.java
@@ -22,7 +22,7 @@ package no.ssb.vtl.script.visitors;
 
 import no.ssb.vtl.parser.VTLBaseVisitor;
 import no.ssb.vtl.parser.VTLParser;
-import no.ssb.vtl.script.error.VTLRuntimeException;
+import no.ssb.vtl.script.error.ContextualRuntimeException;
 
 import javax.script.Bindings;
 
@@ -47,10 +47,7 @@ public abstract class AbstractVariableVisitor<T> extends VTLBaseVisitor<T> {
         if (bindings.containsKey(identifier))
             return identifier;
 
-        throw new VTLRuntimeException(
-                format("undefined variable [%s] (scope [%s])", identifier, bindings),
-                "VTL-101", ctx
-        );
+        throw new ContextualRuntimeException(format("undefined variable %s", ctx.getText()), ctx);
     }
 
     private static String unEscape(String identifier) {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AggregationVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AggregationVisitor.java
@@ -21,23 +21,37 @@ package no.ssb.vtl.script.visitors;
  */
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import no.ssb.vtl.model.Component;
-import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
-import no.ssb.vtl.parser.VTLParser;
+import no.ssb.vtl.parser.VTLParser.AggregationParamsContext;
+import no.ssb.vtl.script.error.ContextualRuntimeException;
 import no.ssb.vtl.script.operations.AggregationOperation;
 import no.ssb.vtl.script.operations.join.ComponentBindings;
 import org.antlr.v4.runtime.Token;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static no.ssb.vtl.parser.VTLParser.ALONG;
+import static no.ssb.vtl.parser.VTLParser.AggregateSumContext;
+import static no.ssb.vtl.parser.VTLParser.GROUP_BY;
+import static no.ssb.vtl.parser.VTLParser.VariableContext;
+import static no.ssb.vtl.parser.VTLParser.VariableExpressionContext;
 
 public class AggregationVisitor extends VTLDatasetExpressionVisitor<AggregationOperation> {
+
+    private static final String NOT_SAME_DATASET_ERROR = "variable %s does not belong to dataset %s";
+    private static final String NOT_AN_IDENTIFIER_ERROR = "variable %s was not an identifier";
 
     private final DatasetExpressionVisitor datasetExpressionVisitor;
     
@@ -49,48 +63,92 @@ public class AggregationVisitor extends VTLDatasetExpressionVisitor<AggregationO
     AggregationVisitor() {
         this.datasetExpressionVisitor = null;
     }
-    
-    @Override
-    public AggregationOperation visitAggregateSum(VTLParser.AggregateSumContext ctx) {
-        Dataset dataset;
-        VTLParser.VariableExpressionContext variable = ctx.variableExpression();
 
-        // Bypass membership.
-        if (variable.membershipExpression() != null) {
-            VTLParser.MembershipExpressionContext membership = variable.membershipExpression();
-            dataset = datasetExpressionVisitor.visit(membership.left);
-            ComponentVisitor componentVisitor = new ComponentVisitor(new ComponentBindings(dataset));
-            Component aggregationComponent = componentVisitor.visit(membership.right);
-            return getSumOperation(dataset, getGroupByComponents(ctx, dataset), Collections.singletonList(aggregationComponent));
-        } else {
-            dataset = datasetExpressionVisitor.visit(variable);
-            return getSumOperation(dataset, getGroupByComponents(ctx, dataset));
+    @Override
+    public AggregationOperation visitAggregateSum(AggregateSumContext ctx) {
+
+        // Get the context that represents our dataset variable.
+        VariableContext datasetContext = extractDatasetContext(ctx.variableExpression());
+
+        // Create a component visitor for the dataset.
+        Dataset dataset = datasetExpressionVisitor.visit(datasetContext);
+        ComponentVisitor componentVisitor = new ComponentVisitor(new ComponentBindings(dataset));
+
+        // All measures or only the one selected.
+        Set<Component> measureComponents = computeMeasureComponentList(
+                ctx.variableExpression(),
+                dataset,
+                componentVisitor
+        );
+
+        Set<Component> aggregationComponents = Sets.newHashSet();
+        AggregationParamsContext paramContexts = ctx.aggregationParams();
+        for (VariableExpressionContext parameterVariableContext : paramContexts.variableExpression()) {
+
+            Optional<VariableContext> datasetVariableCtx = ofNullable(parameterVariableContext.membershipExpression())
+                    .map(membershipContext -> membershipContext.left);
+
+            if (datasetVariableCtx.isPresent()) {
+                // Check that the variable expression uses the same dataset.
+                if (!datasetVariableCtx.get().getText().equals(datasetContext.getText())) {
+                    throw new ContextualRuntimeException(
+                            format(NOT_SAME_DATASET_ERROR, parameterVariableContext.getText(), datasetContext.getText()),
+                            parameterVariableContext
+                    );
+                }
+            }
+
+            VariableContext variableContext = extractComponentContext(parameterVariableContext);
+            Component identifier = componentVisitor.visit(variableContext);
+
+            if (!identifier.isIdentifier()) {
+                throw new ContextualRuntimeException(
+                        format(NOT_AN_IDENTIFIER_ERROR, variableContext.getText()),
+                        parameterVariableContext
+                );
+            }
+
+            aggregationComponents.add(identifier);
         }
+
+        Set<Component> availableIdentifiers = dataset.getDataStructure().values().stream()
+                .filter(Component::isIdentifier)
+                .collect(Collectors.toSet());
+
+        Set<Component> components = computeAggregationComponents(aggregationComponents, availableIdentifiers, paramContexts.aggregationClause);
+        return getSumOperation(dataset, Lists.newArrayList(components), Lists.newArrayList(measureComponents));
     }
-    
-    private Component getComponentFromDataset(Dataset dataset, VTLParser.VariableContext componentRef) {
-        String text = componentRef.getText();
-        DataStructure dataStructure = dataset.getDataStructure();
-        return dataStructure.get(text);
+
+    private Set<Component> computeMeasureComponentList(VariableExpressionContext datasetContext, Dataset dataset, ComponentVisitor componentVisitor) {
+        return Optional.ofNullable(datasetContext.membershipExpression())
+                .map(membershipExpressionContext -> membershipExpressionContext.right)
+                .map(variableContext -> Collections.singleton(componentVisitor.visit(variableContext)))
+                .orElse(dataset.getDataStructure().values().stream().filter(Component::isMeasure).collect(Collectors.toSet()));
     }
-    
-    private List<Component> getGroupByComponents(VTLParser.AggregateSumContext ctx, Dataset dataset) {
-        List<Component> idComponents = ctx.aggregationParams().variableExpression().stream()
-                .map(componentRef -> getComponentFromDataset(dataset, componentRef.variable()))
-                .collect(Collectors.toList());
-        
-        Token clause = ctx.aggregationParams().aggregationClause;
+
+    private Set<Component> computeAggregationComponents(Set<Component> aggregationComponents, Set<Component> availableIdentifiers, Token clause) {
         switch (clause.getType()){
-            case VTLParser.GROUP_BY:
-                return idComponents;
-            case VTLParser.ALONG:
-                return dataset.getDataStructure().values().stream()
-                        .filter(Component::isIdentifier)
-                        .filter(component -> !idComponents.contains(component))
-                        .collect(Collectors.toList());
+            case GROUP_BY:
+                return aggregationComponents;
+            case ALONG:
+                return availableIdentifiers.stream()
+                        .filter(component -> !aggregationComponents.contains(component))
+                        .collect(Collectors.toSet());
             default:
-                throw new IllegalArgumentException("Unrecognized token: " + clause);
+                throw new IllegalArgumentException("unrecognized token: " + clause.getText());
         }
+    }
+
+    private VariableContext extractComponentContext(VariableExpressionContext variableExpressionContext) {
+        return ofNullable(variableExpressionContext.membershipExpression())
+                .map(membershipContext -> membershipContext.right)
+                .orElse(variableExpressionContext.variable());
+    }
+
+    private VariableContext extractDatasetContext(VariableExpressionContext variableExpressionContext) {
+        return ofNullable(variableExpressionContext.membershipExpression())
+                .map(membershipContext -> membershipContext.left)
+                .orElse(variableExpressionContext.variable());
     }
 
     @VisibleForTesting

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AggregationVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AggregationVisitor.java
@@ -60,7 +60,7 @@ public class AggregationVisitor extends VTLDatasetExpressionVisitor<AggregationO
     }
 
     private static Set<Component> computeMeasureComponentList(VariableExpressionContext datasetContext, Dataset dataset, ComponentVisitor componentVisitor) {
-        return Optional.ofNullable(datasetContext.membershipExpression())
+        return ofNullable(datasetContext.membershipExpression())
                 .map(membershipExpressionContext -> membershipExpressionContext.right)
                 .map(variableContext -> Collections.singleton(componentVisitor.visit(variableContext)))
                 .orElse(dataset.getDataStructure().values().stream().filter(Component::isMeasure).collect(Collectors.toSet()));
@@ -114,18 +114,21 @@ public class AggregationVisitor extends VTLDatasetExpressionVisitor<AggregationO
         }
     }
 
+    /**
+     * Checks that the dataset in the variable expression uses the same dataset.
+     */
     private static void checkDatasetContexts(VariableContext datasetContext, VariableExpressionContext parameterVariableContext) {
         Optional<VariableContext> datasetVariableCtx = ofNullable(parameterVariableContext.membershipExpression())
                 .map(membershipContext -> membershipContext.left);
 
-        if (datasetVariableCtx.isPresent()) {
-            // Check that the variable expression uses the same dataset.
-            if (!datasetVariableCtx.get().getText().equals(datasetContext.getText())) {
-                throw new ContextualRuntimeException(
-                        format(NOT_SAME_DATASET_ERROR, parameterVariableContext.getText(), datasetContext.getText()),
-                        parameterVariableContext
-                );
-            }
+        if (!datasetVariableCtx.isPresent())
+            return;
+
+        if (!datasetVariableCtx.get().getText().equals(datasetContext.getText())) {
+            throw new ContextualRuntimeException(
+                    format(NOT_SAME_DATASET_ERROR, parameterVariableContext.getText(), datasetContext.getText()),
+                    parameterVariableContext
+            );
         }
     }
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/AggregationVisitorTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/AggregationVisitorTest.java
@@ -223,7 +223,7 @@ public class AggregationVisitorTest {
     public void testSumSingleMeasureDataSet() throws Exception {
 
         List<Component> components = Lists.newArrayList(datasetSingleMeasure.getDataStructure().getOrDefault("time", null));
-        AggregationOperation sumOperation = visitor.getSumOperation(datasetSingleMeasure,components);
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(datasetSingleMeasure,components);
         sumOperation.getData().forEach(System.out::println);
 
         DataStructure dataStructure = sumOperation.getDataStructure();
@@ -252,7 +252,7 @@ public class AggregationVisitorTest {
     // TODO: Move this to its own test when avg is implemented
     public void testSumMultiMeasureDataSetAll() throws Exception {
         List<Component> groupBy = Lists.newArrayList(datasetMultiMeasure.getDataStructure().getOrDefault("time", null));
-        AggregationOperation sumOperation = visitor.getSumOperation(datasetMultiMeasure,groupBy);
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(datasetMultiMeasure,groupBy);
 
         DataStructure dataStructure = sumOperation.getDataStructure();
 
@@ -283,7 +283,7 @@ public class AggregationVisitorTest {
         Component m1 = dataStructure.getOrDefault("m1", null);
         List<Component> groupBy = Lists.newArrayList(dataStructure.getOrDefault("time", null));
 
-        AggregationOperation sumOperation = visitor.getSumOperation(datasetMultiMeasure,groupBy, Collections.singletonList(m1));
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(datasetMultiMeasure,groupBy, Collections.singletonList(m1));
 
         DataStructure resultingDataStructure = sumOperation.getDataStructure();
 
@@ -312,7 +312,7 @@ public class AggregationVisitorTest {
         DataStructure dataStructure = datasetSingleMeasure.getDataStructure();
         List<Component> components = Lists.newArrayList(dataStructure.get("time"), dataStructure.get("geo"));
         System.out.println("Group By " + components);
-        AggregationOperation sumOperation = visitor.getSumOperation(datasetSingleMeasure,components);
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(datasetSingleMeasure,components);
         sumOperation.getData().forEach(System.out::println);
 
         DataStructure resultingDataStructure = sumOperation.getDataStructure();
@@ -375,7 +375,7 @@ public class AggregationVisitorTest {
                 .filter(component -> !alongComponents.contains(component))
                 .collect(Collectors.toList());
         System.out.println(groupBy);
-        AggregationOperation sumOperation = visitor.getSumOperation(datasetToBeSummed,groupBy);
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(datasetToBeSummed,groupBy);
 
         assertThat(sumOperation.getData()).containsOnly(dataPoint("EIER", "F130KFEIER", "130", "2015", "SBDR", 8418L+1092L+5367L+4370L+318L+610L+3888L+24L));
 
@@ -397,7 +397,7 @@ public class AggregationVisitorTest {
                 .addPoints("2012", "DK", 92L)
                 .build();
 
-        AggregationOperation sumOperation = visitor.getSumOperation(dataset,
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(dataset,
                 Collections.singletonList(dataStructureSingleMeasure.get("time")));
         assertThat(sumOperation.getData()).contains(dataPoint("2012", 41L + 92L));
 
@@ -417,7 +417,7 @@ public class AggregationVisitorTest {
                 .addPoints("2", "shouldFail")
                 .build();
 
-        AggregationOperation sumOperation = visitor.getSumOperation(dataset,
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(dataset,
                 Collections.singletonList(dataStructureSingleMeasure.get("time")));
         sumOperation.getDataStructure();
         fail("Expected an exception but none was thrown");
@@ -441,7 +441,7 @@ public class AggregationVisitorTest {
                 .addPoints("2012", "DK", 92L)
                 .build();
 
-        AggregationOperation sumOperation = visitor.getSumOperation(dataset,
+        AggregationOperation sumOperation = AggregationVisitor.getSumOperation(dataset,
                 Collections.singletonList(dataStructureSingleMeasure.get("time")));
         assertThat(sumOperation.getData()).contains(dataPoint("2012", 41L + 92L));
         assertThat(sumOperation.getData()).contains(dataPoint("2010", null));

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/AggregationVisitorTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/visitors/AggregationVisitorTest.java
@@ -97,6 +97,7 @@ public class AggregationVisitorTest {
                 "geo", Component.Role.IDENTIFIER, String.class,
                 "m1", Component.Role.MEASURE, Long.class,
                 "m2", Component.Role.MEASURE, Long.class);
+
         datasetMultiMeasure = StaticDataset.create(dataStructureMultiMeasure)
                 .addPoints("2010", "NO", 20L, 2L)
                 .addPoints("2010", "SE", 40L, 4L)
@@ -218,6 +219,7 @@ public class AggregationVisitorTest {
     }
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumSingleMeasureDataSet() throws Exception {
 
         List<Component> components = Lists.newArrayList(datasetSingleMeasure.getDataStructure().getOrDefault("time", null));
@@ -247,6 +249,7 @@ public class AggregationVisitorTest {
 
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumMultiMeasureDataSetAll() throws Exception {
         List<Component> groupBy = Lists.newArrayList(datasetMultiMeasure.getDataStructure().getOrDefault("time", null));
         AggregationOperation sumOperation = visitor.getSumOperation(datasetMultiMeasure,groupBy);
@@ -273,6 +276,7 @@ public class AggregationVisitorTest {
     }
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumMultiMeasureDataSet() throws Exception {
 
         DataStructure dataStructure = datasetMultiMeasure.getDataStructure();
@@ -303,6 +307,7 @@ public class AggregationVisitorTest {
 
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumGroupedByMultipleIdentifiers() throws Exception {
         DataStructure dataStructure = datasetSingleMeasure.getDataStructure();
         List<Component> components = Lists.newArrayList(dataStructure.get("time"), dataStructure.get("geo"));
@@ -337,6 +342,7 @@ public class AggregationVisitorTest {
 
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumAlongMultipleIdentifiers() throws Exception {
         Dataset datasetToBeSummed = StaticDataset.create()
                 .addComponent("eieform", Component.Role.IDENTIFIER, String.class)
@@ -376,6 +382,7 @@ public class AggregationVisitorTest {
     }
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumWithNullValues() throws Exception {
         Dataset dataset = StaticDataset.create(dataStructureSingleMeasure)
                 .addPoints("2010", "NO", 20L)
@@ -397,6 +404,8 @@ public class AggregationVisitorTest {
     }
 
     @Test(expected = ParseCancellationException.class)
+    // TODO: Move this to its own test when avg is implemented
+    // TODO: Use assertThrownBy with ContextualRuntimeException.
     public void testAggregationWithoutNumber() throws Exception {
         DataStructure dataStructure = DataStructure.builder()
 
@@ -416,6 +425,7 @@ public class AggregationVisitorTest {
 
 
     @Test
+    // TODO: Move this to its own test when avg is implemented
     public void testSumWithEmptyAggregationGroup() throws Exception {
         //dataset with several null values. In fact ALL 2010 values are null
         Dataset dataset = StaticDataset.create(dataStructureSingleMeasure)


### PR DESCRIPTION
When using membership in the along/group by list of component to aggregate a NPE was thrown.

```
sum(ds) along id
sum(ds) along ds.id       // NPE

sum(ds) group by id
sum(ds) group by ds.id // NPE
```

Since the contextual exception handling is on `develop` I took the time to include thorough error messages in the visitor.