### PR TITLE
Implement streamable union operation

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnionOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnionOperation.java
@@ -9,9 +9,9 @@ package no.ssb.vtl.script.operations;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,10 @@ package no.ssb.vtl.script.operations;
  * =========================LICENSE_END==================================
  */
 
+import com.codepoetics.protonpack.StreamUtils;
+import com.codepoetics.protonpack.selectors.Selector;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import no.ssb.vtl.model.AbstractDatasetOperation;
@@ -34,6 +37,7 @@ import no.ssb.vtl.script.error.VTLRuntimeException;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +53,7 @@ import static java.util.Arrays.asList;
  * Union operator
  */
 public class UnionOperation extends AbstractDatasetOperation {
-    
+
     public UnionOperation(Dataset... dataset) {
         this(asList(dataset));
     }
@@ -61,12 +65,12 @@ public class UnionOperation extends AbstractDatasetOperation {
         while (iterator.hasNext())
             checkDataStructures(firstDataStructure, iterator.next().getDataStructure());
     }
-    
+
     @Override
     protected DataStructure computeDataStructure() {
         return getChildren().get(0).getDataStructure();
     }
-    
+
     private void checkDataStructures(DataStructure baseDataStructure, DataStructure nextDataStructure) {
         // Identifiers and attribute should be equals in name, role and type.
         Set<String> requiredNames = nonAttributeNames(baseDataStructure);
@@ -81,7 +85,7 @@ public class UnionOperation extends AbstractDatasetOperation {
 
         Map<String, Component.Role> requiredRoles = Maps.filterKeys(baseDataStructure.getRoles(), requiredNames::contains);
         Map<String, Component.Role> providedRoles = Maps.filterKeys(nextDataStructure.getRoles(), requiredNames::contains);
-    
+
         checkArgument(
                 requiredRoles.equals(providedRoles),
                 "dataset was incompatible with the required data structure, missing: %s, unexpected %s",
@@ -91,7 +95,7 @@ public class UnionOperation extends AbstractDatasetOperation {
 
         Map<String, Class<?>> requiredTypes = Maps.filterKeys(baseDataStructure.getTypes(), requiredNames::contains);
         Map<String, Class<?>> providedTypes = Maps.filterKeys(nextDataStructure.getTypes(), requiredNames::contains);
-    
+
         checkArgument(
                 requiredTypes.equals(providedTypes),
                 "dataset was incompatible with the required data structure, missing: %s, unexpected %s",
@@ -101,10 +105,72 @@ public class UnionOperation extends AbstractDatasetOperation {
 
     }
 
-    private Set<String> nonAttributeNames(DataStructure dataStructure   ) {
+    private Set<String> nonAttributeNames(DataStructure dataStructure) {
         return Maps.filterValues(dataStructure.getRoles(), role -> role != Component.Role.ATTRIBUTE).keySet();
     }
-            
+
+    @Override
+    public Optional<Stream<DataPoint>> getData(Order orders, Filtering filtering, Set<String> components) {
+        List<Stream<DataPoint>> streams = Lists.newArrayList();
+        for (Dataset dataset : getChildren()) {
+            Optional<Stream<DataPoint>> stream = dataset.getData(orders, filtering, components);
+            if (!stream.isPresent()) return Optional.empty();
+            streams.add(stream.get());
+        }
+
+        Comparator<DataPoint> comparator = Comparator.nullsLast(orders);
+        Stream<DataPoint> result = StreamUtils.interleave(createSelector(comparator), streams);
+        return Optional.of(result);
+    }
+
+    // TODO: Create PR for https://github.com/poetix/protonpack/issues/43
+    private <T> Selector<T> createSelector(Comparator<T> comparator) {
+        return new Selector<T>() {
+
+            private T lastMin = null;
+
+            private boolean isBeforeLast(T dataPoint) {
+                if (lastMin == null)
+                    return false;
+
+                int beforeLast = comparator.compare(dataPoint, lastMin);
+                if (beforeLast == 0) {
+                    throwDuplicateError((DataPoint) dataPoint);
+                    return false;
+                } else {
+                    return beforeLast < 0;
+                }
+            }
+
+
+            @Override
+            public Integer apply(T[] dataPoints) {
+                // Advance the stream that is the most behind.
+                T minBeforeLast = null;
+                T minGlobal = null;
+                int mblIdx = -1;
+                int mgIdx = -1;
+                for (int i = 0; i < dataPoints.length; i++) {
+
+                    T dataPoint = dataPoints[i];
+                    if (isBeforeLast(dataPoint)) {
+
+                        if (comparator.compare(dataPoint, minBeforeLast) < 0) {
+                            mblIdx = i;
+                            minBeforeLast = dataPoint;
+                        }
+
+                    }
+                    if ((minGlobal == null && dataPoint != null) || comparator.compare(dataPoint, minGlobal) < 0) {
+                        mgIdx = i;
+                        minGlobal = dataPoint;
+                    }
+                }
+                return mblIdx < 0 ? mgIdx : mblIdx;
+            }
+        };
+    }
+
     @Override
     public Stream<DataPoint> getData() {
         List<Dataset> datasets = getChildren();
@@ -127,29 +193,34 @@ public class UnionOperation extends AbstractDatasetOperation {
         return getChildren().stream().flatMap(Dataset::getData)
                 .peek((o) -> {
                     if (seen.contains(o)) {
-                        //TODO: define an error code encoding. See VTL User Manuel "Constraints and errors"
-                        Map<Component, VTLObject> row = getDataStructure().asMap(o);
-                        String rowAsString = row.keySet().stream()
-                                .map(k -> k.getRole() + ":" + row.get(k))
-                                .collect(Collectors.joining("\n"));
-                        throw new VTLRuntimeException(String.format("The resulting dataset from a union contains duplicates. Duplicate row: %s", rowAsString), "VTL-1xxx", o);
+                        throwDuplicateError(o);
+                        return;
                     }
                 })
                 .peek(bucket::add);
     }
-    
+
+    private void throwDuplicateError(DataPoint o) {
+        //TODO: define an error code encoding. See VTL User Manuel "Constraints and errors"
+        Map<Component, VTLObject> row = getDataStructure().asMap(o);
+        String rowAsString = row.keySet().stream()
+                .map(k -> k.getRole() + ":" + row.get(k))
+                .collect(Collectors.joining("\n"));
+        throw new VTLRuntimeException(String.format("The resulting dataset from a union contains duplicates. Duplicate row: %s", rowAsString), "VTL-1xxx", o);
+    }
+
     private Map<Component, Order.Direction> rolesInOrder(DataStructure dataStructure, Order.Direction desc, Component.Role... roles) {
         ImmutableSet<Component.Role> roleSet = Sets.immutableEnumSet(Arrays.asList(roles));
         return dataStructure.values().stream()
                 .filter(component -> roleSet.contains(component.getRole()))
                 .collect(Collectors.toMap(o -> o, o -> desc));
     }
-    
+
     @Override
     public Optional<Map<String, Integer>> getDistinctValuesCount() {
         return Optional.empty();
     }
-    
+
     @Override
     public Optional<Long> getSize() {
         return Optional.empty();

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnionOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnionOperation.java
@@ -205,6 +205,10 @@ public class UnionOperation extends AbstractDatasetOperation {
 
     @Override
     public Stream<DataPoint> getData() {
+        Optional<Stream<DataPoint>> ordered = this.getData(Order.createDefault(getDataStructure()));
+        if (ordered.isPresent())
+            return ordered.get();
+
         List<Dataset> datasets = getChildren();
         if (datasets.size() == 1) {
             return datasets.get(0).getData();

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnionOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnionOperationTest.java
@@ -42,7 +42,10 @@ import java.util.stream.Stream;
 import static no.ssb.vtl.model.Component.Role;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class UnionOperationTest {
@@ -62,14 +65,22 @@ public class UnionOperationTest {
     @Test
     public void testOneDatasetReturnedUnchanged() throws Exception {
 
-        Dataset dataset = mock(Dataset.class);
-        when(dataset.getData()).thenReturn(Stream.empty());
+        Dataset dataset = StaticDataset.create().build();
+        Stream<DataPoint> stream = dataset.getData();
+
+        Dataset spyDataset = spy(dataset);
+        doReturn(stream).when(spyDataset).getData();
+        doReturn(stream).when(spyDataset).getData(any(), any(), any());
 
         UnionOperation operator = new UnionOperation(dataset);
 
         assertThat(operator.getData())
-                .as("Check that result of union operation")
-                .isSameAs(dataset.getData());
+                .as("result of union operation")
+                .isSameAs(stream);
+
+        assertThat(operator.getData(Order.createDefault(dataset.getDataStructure())))
+                .as("result of union operation")
+                .isSameAs(stream);
 
     }
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnionOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnionOperationTest.java
@@ -188,13 +188,11 @@ public class UnionOperationTest {
 
         assertThat(resultDataset.getDataStructure()).isEqualTo(dataStructure);
 
-        Stream<DataPoint> stream = resultDataset.getData(Order.createDefault(dataStructure)).orElseThrow(
-                () -> new Exception("could not sort")
-        );
+        Stream<DataPoint> stream = resultDataset.getData();
         assertThat(stream).isNotNull();
 
         assertThat(stream)
-                .containsExactly(
+                .containsExactlyInAnyOrder(
                         dataPoint("2012", "Belgium", 5L),
                         dataPoint("2012", "Greece", 2L),
                         dataPoint("2012", "France", 3L),


### PR DESCRIPTION
Implement streamable union. I implemented two algorithms - `createSelector` and `createSelector2` - the second one is probably better. 

The union basically interleave the values of each ordered stream based on the return value of the Selector returned by `createSelector` and `createSelector2`. That is, the next lowest value. If the previous lowest value selected is bigger that the new lowest, the streams were not sorted. If it is equal we had a duplicate. 