### PR TITLE
Fix ClassCastException when filter check encounters null values

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FilterOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FilterOperation.java
@@ -26,6 +26,7 @@ import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.VTLBoolean;
 import no.ssb.vtl.model.VTLExpression;
+import no.ssb.vtl.model.VTLObject;
 import no.ssb.vtl.script.operations.join.ComponentBindings;
 import no.ssb.vtl.script.operations.join.DataPointBindings;
 
@@ -56,9 +57,8 @@ public class FilterOperation extends AbstractUnaryDatasetOperation {
         return getChild().getData()
                 .map(dataPointBindings::setDataPoint)
                 .filter(bindings -> {
-                    VTLBoolean resolved = (VTLBoolean) predicate.resolve(dataPointBindings);
-                    Boolean predicate = resolved.get();
-                    return predicate == null ? false : predicate;
+                    VTLObject resolved = predicate.resolve(dataPointBindings);
+                    return resolved.get() == null ? false : VTLBoolean.of((Boolean) resolved.get()).get();
                 })
                 .map(DataPointBindings::getDataPoint);
     }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FilterOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FilterOperationTest.java
@@ -42,7 +42,7 @@ public class FilterOperationTest {
     private static VTLExpression NULL = new VTLExpression() {
         @Override
         public VTLObject resolve(Bindings bindings) {
-            return VTLBoolean.of((Boolean) null);
+            return VTLObject.of((VTLObject) null);
         }
 
         @Override
@@ -76,23 +76,24 @@ public class FilterOperationTest {
     };
 
     @Before
-    public void setUp() throws Exception {
-        dataset= StaticDataset.create()
+    public void setUp() {
+        dataset = StaticDataset.create()
                 .addComponent("id", Component.Role.IDENTIFIER, String.class)
-                .addPoints("idValue")
+                .addComponent("mc", Component.Role.MEASURE, String.class)
+                .addPoints("idValue", null)
                 .build();
         componentBindings = new ComponentBindings(dataset);
     }
 
     @Test
-    public void testPredicateReturnsNull() throws Exception {
+    public void testPredicateReturnsNull() {
 
         FilterOperation resultBooleanNull = new FilterOperation(dataset, NULL, componentBindings);
         assertThat(resultBooleanNull.getData()).isEmpty();
     }
 
     @Test
-    public void testPredicateReturnsFalse() throws Exception {
+    public void testPredicateReturnsFalse() {
 
         FilterOperation result = new FilterOperation(dataset, FALSE, componentBindings);
         assertThat(result.getData()).isEmpty();
@@ -100,7 +101,7 @@ public class FilterOperationTest {
 
 
     @Test
-    public void testPredicateReturnsTrue() throws Exception {
+    public void testPredicateReturnsTrue() {
 
         FilterOperation result = new FilterOperation(dataset, TRUE, componentBindings);
         assertThat(result.getData()).isNotEmpty();


### PR DESCRIPTION
When filter on a value encounters a null value, that null value is resolved as (VTLObject)null, which gave a ClassCastException when trying to cast the result to VTLBoolean. This is solved by only casting to VTLBoolean if the value is not null.