### PR TITLE
Close stream

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnfoldOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/UnfoldOperation.java
@@ -83,7 +83,7 @@ public class UnfoldOperation extends AbstractUnaryDatasetOperation {
         // Try to get data sorted as required. If impossible, sort it.
         Stream<? extends DataPoint> stream = getChild()
                 .getData(requiredOrder)
-                .orElse(getChild().getData().sorted(requiredOrder));
+                .orElseGet(() -> getChild().getData().sorted(requiredOrder));
 
 
         return StreamUtils.aggregate(stream, (left, right) -> {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CrossJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CrossJoinOperation.java
@@ -99,7 +99,8 @@ public class CrossJoinOperation extends OuterJoinOperation {
     }
 
     private Stream<DataPoint> order(Order requestedOrder, Filtering filtering, Set<String> components, Dataset first) {
-        return first.getData(requestedOrder, filtering, components).orElse(
-                first.getData().sorted(requestedOrder).filter(filtering));
+        return first.getData(requestedOrder, filtering, components).orElseGet(
+                () -> first.getData().sorted(requestedOrder).filter(filtering)
+        );
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/support/VTLPrintStream.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/support/VTLPrintStream.java
@@ -20,15 +20,13 @@ package no.ssb.vtl.script.support;
  * =========================LICENSE_END==================================
  */
 
-import no.ssb.vtl.model.Component;
-import no.ssb.vtl.model.VTLObject;
-import no.ssb.vtl.model.DataStructure;
-import no.ssb.vtl.model.Dataset;
+import no.ssb.vtl.model.*;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@link PrintStream} that can print vtl objects
@@ -60,15 +58,17 @@ public class VTLPrintStream extends PrintStream {
                         )
                         .collect(Collectors.toList())
         );
-        dataset.getData().forEach(tuple -> {
-            table.addRow(
-                    tuple.stream()
-                            .map(VTLObject::get)
-                            .map(o -> o == null ? "[NULL]" : o)
-                            .map(Object::toString)
-                            .collect(Collectors.toList())
-            );
-        });
+        try (Stream<DataPoint> data = dataset.getData()) {
+            data.forEach(tuple -> {
+                table.addRow(
+                        tuple.stream()
+                                .map(VTLObject::get)
+                                .map(o -> o == null ? "[NULL]" : o)
+                                .map(Object::toString)
+                                .collect(Collectors.toList())
+                );
+            });
+        }
         table.showTable(this);
     }
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/AggregationOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/AggregationOperationTest.java
@@ -1,5 +1,29 @@
 package no.ssb.vtl.script.operations;
 
+/*
+ * -
+ *  * ========================LICENSE_START=================================
+ * * Java VTL
+ *  *
+ * %%
+ * Copyright (C) 2017 Hadrien Kohl
+ *  *
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ *
+ */
+
 import com.google.common.collect.ImmutableList;
 import no.ssb.vtl.model.*;
 import no.ssb.vtl.script.support.DatasetCloseWatcher;
@@ -16,7 +40,7 @@ public class AggregationOperationTest {
     private DatasetCloseWatcher dataset;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
 
         StaticDataset staticDataset = StaticDataset.create()
                 .addComponent("id1", Role.IDENTIFIER, String.class)

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/AggregationOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/AggregationOperationTest.java
@@ -1,0 +1,69 @@
+package no.ssb.vtl.script.operations;
+
+import com.google.common.collect.ImmutableList;
+import no.ssb.vtl.model.*;
+import no.ssb.vtl.script.support.DatasetCloseWatcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import static no.ssb.vtl.model.Component.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AggregationOperationTest {
+
+    private DatasetCloseWatcher dataset;
+
+    @Before
+    public void setUp() throws Exception {
+
+        StaticDataset staticDataset = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("id2", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.IDENTIFIER, Long.class)
+
+                .addPoints("a", "1", 1L)
+                .addPoints("a", "2", 2L)
+                .addPoints("a", "3", 4L)
+                .addPoints("a", "4", 8L)
+
+                .addPoints("b", "1", 1L)
+                .addPoints("b", "2", 2L)
+                .addPoints("b", "3", 4L)
+                .addPoints("b", "4", 8L)
+
+                .addPoints("c", "1", 1L)
+                .addPoints("c", "2", 2L)
+                .addPoints("c", "3", 4L)
+                .addPoints("c", "4", 8L)
+
+                .build();
+
+        this.dataset = DatasetCloseWatcher.wrap(staticDataset);
+    }
+
+    @Test
+    public void testClosesStreams() {
+
+
+        DataStructure structure = this.dataset.getDataStructure();
+        AggregationOperation aggregationOperation = new AggregationOperation(
+                this.dataset,
+                ImmutableList.of(structure.get("id1")),
+                ImmutableList.of(structure.get("m1")),
+                vtlNumbers -> vtlNumbers.stream().reduce(VTLNumber.of(0L), VTLNumber::add)
+        );
+
+        try (Stream<DataPoint> data = aggregationOperation.getData()) {
+            assertThat(data).containsExactly(
+                    DataPoint.create("a",15),
+                    DataPoint.create("b",15),
+                    DataPoint.create("c",15)
+            );
+        } finally {
+            assertThat(dataset.allStreamWereClosed()).isTrue();
+        }
+
+    }
+}

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/JoinAssignmentTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/JoinAssignmentTest.java
@@ -34,6 +34,8 @@ import no.ssb.vtl.model.VTLInteger;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 import no.ssb.vtl.model.VTLString;
+import no.ssb.vtl.script.operations.join.ComponentBindings;
+import no.ssb.vtl.script.support.DatasetCloseWatcher;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
@@ -42,20 +44,23 @@ import org.junit.Test;
 
 import javax.script.Bindings;
 import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JoinAssignmentTest {
     private VTLExpression expression;
-    private Dataset dataset;
+    private DatasetCloseWatcher dataset;
 
     @Rule
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         expression = new VTLExpression() {
             @Override
             public VTLObject resolve(Bindings bindings) {
@@ -76,16 +81,16 @@ public class JoinAssignmentTest {
 
         DataPoint dataPoint = DataPoint.create(3);
         dataPoint.set(0, VTLObject.of("idValue"));
-        dataPoint.set(0, VTLObject.of("measureValue"));
-        dataPoint.set(0, VTLObject.of("attrValue"));
+        dataPoint.set(1, VTLObject.of("measureValue"));
+        dataPoint.set(2, VTLObject.of("attrValue"));
 
-        dataset = StaticDataset.create(structure)
+        dataset = DatasetCloseWatcher.wrap(StaticDataset.create(structure)
                 .addPoints(dataPoint)
-                .build();
+                .build());
     }
 
     @Test
-    public void testTypeConversion() throws Exception {
+    public void testTypeConversion() {
         ImmutableMap<Class<? extends VTLObject>, Class<?>> types = ImmutableMap.<Class<? extends VTLObject>, Class<?>>builder()
                 .put(VTLNumber.class, Number.class)
                 .put(VTLInteger.class, Long.class)
@@ -104,7 +109,7 @@ public class JoinAssignmentTest {
 
     // Replacing identifier is not allowed.
     @Test
-    public void testIdentifierFails() throws Exception {
+    public void testIdentifierFails() {
 
         List<JoinAssignment> operations = Lists.newArrayList(
                 new JoinAssignment(dataset, expression, "id", Component.Role.IDENTIFIER, true),
@@ -123,7 +128,7 @@ public class JoinAssignmentTest {
 
     // When using implicit the role must be the same if the component is already present.
     @Test
-    public void testImplicitFails() throws Exception {
+    public void testImplicitFails() {
 
         List<JoinAssignment> operations = Lists.newArrayList(
                 new JoinAssignment(dataset, expression, "measure", Component.Role.MEASURE, true),
@@ -147,9 +152,53 @@ public class JoinAssignmentTest {
         }
     }
 
+    @Test
+    public void testNewAttributeValue() {
+
+        JoinAssignment operation;
+        operation = new JoinAssignment(
+                dataset,
+                expression,
+                "attr",
+                Component.Role.ATTRIBUTE,
+                false,
+                new ComponentBindings(Collections.emptyMap())
+        );
+        try (Stream<DataPoint> data = operation.getData()) {
+            assertThat(data.map(dp -> dp.get(2))).containsExactly(
+                    VTLObject.of("changed")
+            );
+        } finally {
+            assertThat(dataset.allStreamWereClosed()).isTrue();
+        }
+
+    }
+
+    @Test
+    public void testNewMeasureValue() {
+
+        JoinAssignment operation;
+        operation = new JoinAssignment(
+                dataset,
+                expression,
+                "measure",
+                Component.Role.ATTRIBUTE,
+                false,
+                new ComponentBindings(Collections.emptyMap())
+        );
+        try (Stream<DataPoint> data = operation.getData()) {
+            assertThat(data.map(dp -> dp.get(1))).containsExactly(
+                    VTLObject.of("changed")
+            );
+        } finally {
+            assertThat(dataset.allStreamWereClosed()).isTrue();
+        }
+
+    }
+
     // Measure and attribute roles can be changed.
     @Test
-    public void testChangeRoles() throws Exception {
+    public void testChangeRoles() {
 
         JoinAssignment operation;
 
@@ -166,7 +215,7 @@ public class JoinAssignmentTest {
     }
 
     @Test
-    public void testNewRoles() throws Exception {
+    public void testNewRoles() {
 
         JoinAssignment operation;
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/JoinAssignmentTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/JoinAssignmentTest.java
@@ -182,7 +182,7 @@ public class JoinAssignmentTest {
                 dataset,
                 expression,
                 "measure",
-                Component.Role.ATTRIBUTE,
+                Component.Role.MEASURE,
                 false,
                 new ComponentBindings(Collections.emptyMap())
         );

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnfoldOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnfoldOperationTest.java
@@ -21,45 +21,29 @@ package no.ssb.vtl.script.operations;
  */
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import no.ssb.vtl.model.Component;
-import no.ssb.vtl.model.DataPoint;
-import no.ssb.vtl.model.DataStructure;
-import no.ssb.vtl.model.Dataset;
-import no.ssb.vtl.model.Order;
-import no.ssb.vtl.model.VTLObject;
+import no.ssb.vtl.model.*;
+import no.ssb.vtl.script.support.DatasetCloseWatcher;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.*;
 import static no.ssb.vtl.model.Component.Role.*;
 import static org.mockito.Mockito.*;
 
 public class UnfoldOperationTest {
 
-    private static DataPoint tuple(DataStructure structure, Object... values) {
-        checkArgument(values.length == structure.size());
-        Map<String, Object> map = Maps.newLinkedHashMap();
-        Iterator<Object> iterator = Lists.newArrayList(values).iterator();
-        for (String name : structure.keySet()) {
-            map.put(name, iterator.next());
-        }
-        return structure.wrap(map);
+    @Test
+    public void testStreamClosed() {
+
     }
 
     @Test
-    public void testArguments() throws Exception {
+    public void testArguments() {
 
         Dataset dataset = mock(Dataset.class);
         Component validIdentifierReference = mock(Component.class);
@@ -96,7 +80,7 @@ public class UnfoldOperationTest {
     }
 
     @Test
-    public void testConstraint() throws Exception {
+    public void testConstraint() {
 
         Set<String> validElements = Sets.newHashSet("some value");
         DataStructure structure = DataStructure.of(
@@ -145,75 +129,45 @@ public class UnfoldOperationTest {
     }
 
     @Test
-    public void testUnfoldUnsorted() throws Exception {
-        Set<String> elements = Sets.newLinkedHashSet(Arrays.asList("id2-1", "id2-2"));
-        Dataset dataset = mock(Dataset.class);
-
-        DataStructure structure = DataStructure.of(
-                "id1", IDENTIFIER, String.class,
-                "id2", IDENTIFIER, String.class,
-                "measure1", MEASURE, String.class,
-                "measure2", MEASURE, String.class,
-                "attribute1", ATTRIBUTE, String.class
-        );
-        when(dataset.getDataStructure()).thenReturn(structure);
-
-        ArrayList<DataPoint> data = Lists.newArrayList(
-                tuple(structure, "id1-1", "id2-1", "measure1-1", "measure2-1", "attribute1-1"),
-                tuple(structure, "id1-1", "id2-2", "measure1-2", "measure2-2", "attribute1-2"),
-                tuple(structure, "id1-2", "id2-1", "measure1-3", "measure2-3", "attribute1-3"),
-                tuple(structure, "id1-2", "id2-2", "measure1-4", "measure2-4", "attribute1-4"),
-                tuple(structure, "id1-3", "id2-1", "measure1-5", "measure2-5", "attribute1-5")
-        );
-        Collections.shuffle(data);
-
-        when(dataset.getData()).then(invocation -> Stream.of(
-
-        ));
-
-    }
-
-    @Test
     @Repeat(iterations = 10)
-    public void testUnfold() throws Exception {
+    public void testUnfold() {
 
         Set<String> elements = Sets.newLinkedHashSet(Arrays.asList("id2-1", "id2-2"));
-        Dataset dataset = mock(Dataset.class);
+        DatasetCloseWatcher dataset = DatasetCloseWatcher.wrap(StaticDataset.create()
+                .addComponent( "id1", IDENTIFIER, String.class)
+                .addComponent( "id2", IDENTIFIER, String.class)
+                .addComponent( "measure1", MEASURE, String.class)
+                .addComponent( "measure2", MEASURE, String.class)
+                .addComponent( "attribute1", ATTRIBUTE, String.class)
 
-        DataStructure structure = DataStructure.of(
-                "id1", IDENTIFIER, String.class,
-                "id2", IDENTIFIER, String.class,
-                "measure1", MEASURE, String.class,
-                "measure2", MEASURE, String.class,
-                "attribute1", ATTRIBUTE, String.class
-        );
-        when(dataset.getDataStructure()).thenReturn(structure);
+                .addPoints("id1-1", "id2-1", "measure1-1", "measure2-1", "attribute1-1")
+                .addPoints("id1-1", "id2-2", "measure1-2", "measure2-2", "attribute1-2")
+                .addPoints("id1-2", "id2-1", "measure1-3", "measure2-3", "attribute1-3")
+                .addPoints("id1-2", "id2-2", "measure1-4", "measure2-4", "attribute1-4")
+                .addPoints("id1-3", "id2-1", "measure1-5", "measure2-5", "attribute1-5")
 
-        ArrayList<DataPoint> data = Lists.newArrayList(
-                tuple(structure, "id1-1", "id2-1", "measure1-1", "measure2-1", "attribute1-1"),
-                tuple(structure, "id1-1", "id2-2", "measure1-2", "measure2-2", "attribute1-2"),
-                tuple(structure, "id1-2", "id2-1", "measure1-3", "measure2-3", "attribute1-3"),
-                tuple(structure, "id1-2", "id2-2", "measure1-4", "measure2-4", "attribute1-4"),
-                tuple(structure, "id1-3", "id2-1", "measure1-5", "measure2-5", "attribute1-5")
-        );
-        Collections.shuffle(data);
+                .build());
 
-        when(dataset.getData()).then(invocation -> data.stream());
-        when(dataset.getData(any(Order.class))).thenReturn(Optional.empty());
+        //Collections.shuffle(data);
 
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
+            DataStructure structure = dataset.getDataStructure();
             UnfoldOperation clause = new UnfoldOperation(dataset, structure.get("id2"), structure.get("measure1"), elements);
 
             softly.assertThat(clause.getDataStructure()).containsOnlyKeys(
                     "id1", "id2-1", "id2-2"
             );
 
-            softly.assertThat(clause.getData()).flatExtracting(input -> input).extracting(VTLObject::get)
+            Stream<DataPoint> stream = clause.getData();
+            softly.assertThat(stream).flatExtracting(input -> input).extracting(VTLObject::get)
                     .containsExactly(
                             "id1-1", "measure1-1", "measure1-2",
                             "id1-2", "measure1-3", "measure1-4",
                             "id1-3", "measure1-5", null
                     );
+            stream.close();
+
+            softly.assertThat(dataset.allStreamWereClosed()).isTrue();
         }
     }
 }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnfoldOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/UnfoldOperationTest.java
@@ -38,11 +38,6 @@ import static org.mockito.Mockito.*;
 public class UnfoldOperationTest {
 
     @Test
-    public void testStreamClosed() {
-
-    }
-
-    @Test
     public void testArguments() {
 
         Dataset dataset = mock(Dataset.class);

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/support/DatasetCloseWatcher.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/support/DatasetCloseWatcher.java
@@ -1,0 +1,90 @@
+package no.ssb.vtl.script.support;
+
+import com.google.common.collect.ForwardingObject;
+import no.ssb.vtl.model.DataPoint;
+import no.ssb.vtl.model.DataStructure;
+import no.ssb.vtl.model.Dataset;
+import no.ssb.vtl.model.Order;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public abstract class DatasetCloseWatcher extends ForwardingObject implements Dataset {
+
+    private int counter = 0;
+
+    private DatasetCloseWatcher() {
+        // disable
+    }
+
+    protected abstract Dataset delegate();
+
+    public boolean allStreamWereClosed() {
+        return counter == 0;
+    }
+
+    public static DatasetCloseWatcher wrap(Dataset dataset) {
+        return new DatasetCloseWatcher() {
+
+            @Override
+            protected Dataset delegate() {
+                return dataset;
+            }
+        };
+    }
+
+    @Override
+    public Stream<DataPoint> getData() {
+        return wrap(delegate().getData());
+    }
+
+    private void increase() {
+        this.counter++;
+    }
+
+    private void decrease() {
+        this.counter--;
+    }
+
+    private Stream<DataPoint> wrap(Stream<DataPoint> stream) {
+        this.increase();
+        return stream.onClose(this::decrease);
+    }
+
+    @Override
+    public Optional<Stream<DataPoint>> getData(Order orders, Filtering filtering, Set<String> components) {
+        return delegate().getData(orders, filtering, components).map(this::wrap);
+    }
+
+    @Override
+    public Optional<Stream<DataPoint>> getData(Order order) {
+        return delegate().getData(order).map(this::wrap);
+    }
+
+    @Override
+    public Optional<Stream<DataPoint>> getData(Filtering filtering) {
+        return getData(filtering).map(this::wrap);
+    }
+
+    @Override
+    public Optional<Stream<DataPoint>> getData(Set<String> components) {
+        return getData(components).map(this::wrap);
+    }
+
+    @Override
+    public Optional<Map<String, Integer>> getDistinctValuesCount() {
+        return delegate().getDistinctValuesCount();
+    }
+
+    @Override
+    public Optional<Long> getSize() {
+        return delegate().getSize();
+    }
+
+    @Override
+    public DataStructure getDataStructure() {
+        return delegate().getDataStructure();
+    }
+}

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/support/DatasetCloseWatcher.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/support/DatasetCloseWatcher.java
@@ -1,5 +1,29 @@
 package no.ssb.vtl.script.support;
 
+/*
+ * -
+ *  * ========================LICENSE_START=================================
+ * * Java VTL
+ *  *
+ * %%
+ * Copyright (C) 2017 Hadrien Kohl
+ *  *
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ *
+ */
+
 import com.google.common.collect.ForwardingObject;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
@@ -65,12 +89,12 @@ public abstract class DatasetCloseWatcher extends ForwardingObject implements Da
 
     @Override
     public Optional<Stream<DataPoint>> getData(Filtering filtering) {
-        return getData(filtering).map(this::wrap);
+        return delegate().getData(filtering).map(this::wrap);
     }
 
     @Override
     public Optional<Stream<DataPoint>> getData(Set<String> components) {
-        return getData(components).map(this::wrap);
+        return delegate().getData(components).map(this::wrap);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
             <dependency>
                 <groupId>com.codepoetics</groupId>
                 <artifactId>protonpack</artifactId>
-                <version>1.10</version>
+                <version>1.15</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR add tests that ensure the streams (`getData()`) used in the operations are closed.

The UnfoldOperation and CrossJoinOperation were not closing the streams. This was fixed by upgrading to protonpack 1.15 and ensuring no `orElse()` is used on the `Optional<Stream<DataPoint>>` result of `getData()`.