### PR TITLE
Return concrete type in round function

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/expressions/arithmetic/AbstractArithmeticExpression.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/expressions/arithmetic/AbstractArithmeticExpression.java
@@ -40,19 +40,12 @@ public abstract class AbstractArithmeticExpression extends AbstractNullFirstExpr
     @Override
     public Class getVTLType() {
         if (type == null) {
-            if (hasOperandOfType(VTLNumber.class)) {
-                type = VTLNumber.class;
-            }
-            else if (hasOperandOfType(VTLFloat.class))
+            if (getLeftOperand().getVTLType() == VTLFloat.class || getRightOperand().getVTLType() == VTLFloat.class)
                 type = VTLFloat.class;
             else
                 type = VTLInteger.class;
         }
         return type;
-    }
-
-    private boolean hasOperandOfType(Class clazz) {
-        return getLeftOperand().getVTLType() == clazz || getRightOperand().getVTLType() == clazz;
     }
 
     @Override

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
@@ -20,14 +20,15 @@ package no.ssb.vtl.script.functions;
  * =========================LICENSE_END==================================
  */
 
+import no.ssb.vtl.model.VTLFloat;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 
 import java.math.BigDecimal;
 
-import static java.lang.String.*;
+import static java.lang.String.format;
 
-public class VTLRound extends AbstractVTLFunction<VTLNumber> {
+public class VTLRound extends AbstractVTLFunction<VTLFloat> {
 
     private static final String ARGUMENT_GREATER_THAT_ZERO = "%s must be greater than zero, was %s";
     private static final Argument<VTLNumber> DS = new Argument<>("ds", VTLNumber.class);
@@ -35,7 +36,7 @@ public class VTLRound extends AbstractVTLFunction<VTLNumber> {
     private static VTLRound instance;
 
     private VTLRound() {
-        super("round", VTLNumber.class, DS, DECIMALS);
+        super("round", VTLFloat.class, DS, DECIMALS);
     }
 
     public static VTLRound getInstance() {
@@ -46,7 +47,7 @@ public class VTLRound extends AbstractVTLFunction<VTLNumber> {
     }
 
     @Override
-    protected VTLNumber safeInvoke(TypeSafeArguments arguments) {
+    protected VTLFloat safeInvoke(TypeSafeArguments arguments) {
 
         VTLNumber ds = arguments.get(DS);
         VTLNumber decimals = arguments.get(DECIMALS);
@@ -62,6 +63,7 @@ public class VTLRound extends AbstractVTLFunction<VTLNumber> {
 
         BigDecimal bigDecimal = BigDecimal.valueOf(ds.get().doubleValue());
         BigDecimal rounded = bigDecimal.setScale(decimals.get().intValue(), BigDecimal.ROUND_HALF_UP);
-        return decimals.get().intValue() > 0 ? VTLObject.of(rounded.doubleValue()) : VTLObject.of(rounded.intValue());
+
+        return VTLObject.of(rounded.doubleValue());
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLTrunc.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLTrunc.java
@@ -20,6 +20,7 @@ package no.ssb.vtl.script.functions;
  * =========================LICENSE_END==================================
  */
 
+import no.ssb.vtl.model.VTLFloat;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 
@@ -27,14 +28,14 @@ import java.math.BigDecimal;
 
 import static java.lang.String.format;
 
-public class VTLTrunc extends AbstractVTLFunction<VTLNumber> {
+public class VTLTrunc extends AbstractVTLFunction<VTLFloat> {
 
     private static final Argument<VTLNumber> DS = new Argument<>("ds", VTLNumber.class);
     private static final Argument<VTLNumber> DECIMALS = new Argument<>("decimals", VTLNumber.class);
     private static VTLTrunc instance;
 
     private VTLTrunc() {
-        super("trunc", VTLNumber.class, DS, DECIMALS);
+        super("trunc", VTLFloat.class, DS, DECIMALS);
     }
 
     public static VTLTrunc getInstance() {
@@ -45,7 +46,7 @@ public class VTLTrunc extends AbstractVTLFunction<VTLNumber> {
     }
 
     @Override
-    protected VTLNumber safeInvoke(TypeSafeArguments arguments) {
+    protected VTLFloat safeInvoke(TypeSafeArguments arguments) {
 
         VTLNumber ds = arguments.get(DS);
         VTLNumber decimals = arguments.get(DECIMALS);
@@ -62,6 +63,6 @@ public class VTLTrunc extends AbstractVTLFunction<VTLNumber> {
         BigDecimal bigDecimal = BigDecimal.valueOf(ds.get().doubleValue());
         BigDecimal rounded = bigDecimal.setScale(decimals.get().intValue(), BigDecimal.ROUND_DOWN);
 
-        return decimals.get().intValue() > 0 ? VTLObject.of(rounded.doubleValue()) : VTLObject.of(rounded.intValue());
+        return VTLObject.of(rounded.doubleValue());
     }
 }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/expressions/arithmetic/AbstractArithmeticExpressionTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/expressions/arithmetic/AbstractArithmeticExpressionTest.java
@@ -34,7 +34,8 @@ import javax.script.SimpleBindings;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AbstractArithmeticExpressionTest {
 
@@ -42,7 +43,6 @@ public class AbstractArithmeticExpressionTest {
     public JUnitSoftAssertions softly = new JUnitSoftAssertions();
     private VTLExpression floatExpr;
     private VTLExpression integerExpr;
-    private VTLExpression numberExpr;
 
     private static VTLExpression createExpression(Class<? extends VTLObject> type, VTLObject value) {
         return new VTLExpression() {
@@ -59,19 +59,16 @@ public class AbstractArithmeticExpressionTest {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         integerExpr = mock(VTLExpression.class);
         when(integerExpr.getVTLType()).thenReturn(VTLInteger.class);
 
         floatExpr = mock(VTLExpression.class);
         when(floatExpr.getVTLType()).thenReturn(VTLFloat.class);
-
-        numberExpr = mock(VTLExpression.class);
-        when(numberExpr.getVTLType()).thenReturn(VTLNumber.class);
     }
 
     @Test
-    public void testFailsFast() {
+    public void testFailsFast() throws Exception {
         VTLExpression mock = mock(VTLExpression.class);
 
         softly.assertThatThrownBy(() -> new TestableExpression(null, null))
@@ -88,7 +85,7 @@ public class AbstractArithmeticExpressionTest {
     }
 
     @Test
-    public void testTypes() {
+    public void testTypes() throws Exception {
         softly.assertThat(new TestableExpression(integerExpr, integerExpr).getVTLType())
                 .as("type returned by abstract arithmetic expression")
                 .isAssignableFrom(VTLInteger.class);
@@ -97,10 +94,6 @@ public class AbstractArithmeticExpressionTest {
                 .as("type returned by abstract arithmetic expression with float operand")
                 .isAssignableFrom(VTLFloat.class);
 
-        softly.assertThat(new TestableExpression(numberExpr, integerExpr).getVTLType())
-                .as("type returned by abstract arithmetic expression with float operand")
-                .isAssignableFrom(VTLNumber.class);
-
         softly.assertThat(new TestableExpression(integerExpr, floatExpr).getVTLType())
                 .as("type returned by abstract arithmetic expression with float operand")
                 .isAssignableFrom(VTLFloat.class);
@@ -108,37 +101,16 @@ public class AbstractArithmeticExpressionTest {
         softly.assertThat(new TestableExpression(floatExpr, floatExpr).getVTLType())
                 .as("type returned by abstract arithmetic expression with float operand")
                 .isAssignableFrom(VTLFloat.class);
-
-        softly.assertThat(new TestableExpression(numberExpr, floatExpr).getVTLType())
-                .as("type returned by abstract arithmetic expression with float operand")
-                .isAssignableFrom(VTLNumber.class);
-
-        softly.assertThat(new TestableExpression(integerExpr, numberExpr).getVTLType())
-                .as("type returned by abstract arithmetic expression with float operand")
-                .isAssignableFrom(VTLNumber.class);
-
-        softly.assertThat(new TestableExpression(floatExpr, numberExpr).getVTLType())
-                .as("type returned by abstract arithmetic expression with float operand")
-                .isAssignableFrom(VTLNumber.class);
-
-        softly.assertThat(new TestableExpression(numberExpr, numberExpr).getVTLType())
-                .as("type returned by abstract arithmetic expression with float operand")
-                .isAssignableFrom(VTLNumber.class);
     }
 
     @Test
-    public void testNulls() {
+    public void testNulls() throws Exception {
 
         List<Class<? extends VTLObject>> expressionTypes = Arrays.asList(
                 VTLInteger.class, VTLInteger.class,
                 VTLFloat.class, VTLInteger.class,
-                VTLNumber.class, VTLInteger.class,
                 VTLInteger.class, VTLFloat.class,
-                VTLFloat.class, VTLFloat.class,
-                VTLNumber.class, VTLFloat.class,
-                VTLInteger.class, VTLNumber.class,
-                VTLFloat.class, VTLNumber.class,
-                VTLNumber.class, VTLNumber.class
+                VTLFloat.class, VTLFloat.class
         );
 
         List<VTLObject> expressionValues = Arrays.asList(

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLRoundTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLRoundTest.java
@@ -26,7 +26,8 @@ import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
 
@@ -99,7 +100,7 @@ public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
     }
 
     @Test
-    public void testInvokeWithNegativeDecimalNumber() {
+    public void testInvokeWithNegativeDecimalNumber() throws Exception {
         assertThatThrownBy(() -> vtlBinaryFunction.invoke(
                 Lists.newArrayList(
                         VTLNumber.of(3.444445),
@@ -109,18 +110,5 @@ public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
                 .as("exception when passing a negative number where a positive value is expected")
                 .hasMessage("Argument{name=decimals, type=VTLNumber} must be greater than zero, was -5")
                 .isExactlyInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void testInvokeWithZeroDecimals() {
-        VTLObject<?> result = vtlBinaryFunction.invoke(
-                Lists.newArrayList(
-                        VTLNumber.of(10.1234),
-                        VTLNumber.of(0)
-                )
-        );
-
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(VTLNumber.of(10));
     }
 }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLTruncTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLTruncTest.java
@@ -70,7 +70,7 @@ public class VTLTruncTest extends AbstractVTLNumberBinaryFunctionTest {
         );
 
         assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(VTLNumber.of(5));
+        assertThat(result).isEqualTo(VTLNumber.of(5.0));
     }
 
     @Test


### PR DESCRIPTION
Remove the possibility for functions to return abstract types. This is to avoid the need to look at the data to figure out the type.