### PR TITLE
Merger mutate left row in buffers

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinMerger.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinMerger.java
@@ -77,9 +77,10 @@ public class InnerJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
 
     @Override
     public DataPoint apply(DataPoint left, DataPoint right) {
+        DataPoint result = (DataPoint) left.clone();
         for (Map.Entry<Integer, Integer> entry : indexMap.entries()) {
-            left.set(entry.getValue(), right.get(entry.getKey()));
+            result.set(entry.getValue(), right.get(entry.getKey()));
         }
-        return left;
+        return result;
     }
 }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinMergerTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinMergerTest.java
@@ -52,7 +52,6 @@ public class InnerJoinMergerTest extends RandomizedTest {
                 .put("E", Component.Role.IDENTIFIER, String.class)
                 .put("F", Component.Role.IDENTIFIER, String.class)
                 .build();
-
     }
 
     private DataStructure randomDataStructure(int size) {
@@ -67,6 +66,22 @@ public class InnerJoinMergerTest extends RandomizedTest {
             }
         }
         return builder.build();
+    }
+
+    @Test
+    public void testLeftRowIsCloned() {
+        int rightStructureSize = randomIntBetween(dataStructure.size() / 2, dataStructure.size());
+        int leftStructureSize = randomIntBetween(dataStructure.size() / 2, dataStructure.size());
+
+        DataStructure left = randomDataStructure(leftStructureSize);
+        DataStructure right = randomDataStructure(rightStructureSize);
+
+        InnerJoinMerger merger = new InnerJoinMerger(left, right);
+        DataPoint leftDataPoint = DataPoint.create(left.size());
+        DataPoint rightDataPoint = DataPoint.create(right.keySet().stream().map(s -> CharMatcher.digit().removeFrom(s)).toArray());
+
+        DataPoint result = merger.apply(leftDataPoint, rightDataPoint);
+        assertThat(result).isNotSameAs(leftDataPoint);
     }
 
     @Test
@@ -96,8 +111,7 @@ public class InnerJoinMergerTest extends RandomizedTest {
         DataPoint leftDataPoint = DataPoint.create(left.size());
 
         // Extracting the identifiers of the components from the values.
-        List<String> rightNames = right.keySet().stream().map(s -> CharMatcher.digit().removeFrom(s)).collect(toList());
-        DataPoint rightDataPoint = DataPoint.create(rightNames.toArray());
+        DataPoint rightDataPoint = DataPoint.create(right.keySet().stream().map(s -> CharMatcher.digit().removeFrom(s)).toArray());
 
         DataPoint result = merger.apply(leftDataPoint, rightDataPoint);
 


### PR DESCRIPTION
If an operation after tje join opration reduces the number of rows capacity of the datapoints the instances of the left rows in the join buffer are mutated. 

There are several places we could create a copy of the left row; merger, spliterator, or cartesian iterator. I chose to put it in the merger to be safe but it is something we should reevaluate later.