### PR TITLE
Add support for round on non finite values

### DIFF
--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLFloat.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLFloat.java
@@ -20,6 +20,8 @@ package no.ssb.vtl.model;
 
 public abstract class VTLFloat extends VTLNumber<Double>  implements VTLTyped<VTLFloat> {
 
+    public static final VTLFloat NULL = VTLFloat.of((Float) null);
+
     private VTLFloat() {
     }
 

--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLInteger.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/VTLInteger.java
@@ -20,6 +20,8 @@ package no.ssb.vtl.model;
 
 public abstract class VTLInteger extends VTLNumber<Long>  implements VTLTyped<VTLInteger> {
 
+    public static final VTLInteger NULL = VTLInteger.of((Integer) null);
+
     private VTLInteger() {
     }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLFloor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLFloor.java
@@ -22,9 +22,8 @@ package no.ssb.vtl.script.functions;
 
 import no.ssb.vtl.model.VTLInteger;
 import no.ssb.vtl.model.VTLNumber;
-import no.ssb.vtl.model.VTLObject;
 
-public class VTLFloor extends AbstractVTLFunction<VTLInteger>{
+public class VTLFloor extends AbstractVTLFunction<VTLInteger> {
 
     private static final Argument<VTLNumber> DS = new Argument<>("ds", VTLNumber.class);
     private static VTLFloor instance;
@@ -42,10 +41,10 @@ public class VTLFloor extends AbstractVTLFunction<VTLInteger>{
 
     @Override
     protected VTLInteger safeInvoke(TypeSafeArguments arguments) {
-        VTLNumber ds = arguments.get(DS);
+        VTLNumber ds = arguments.getNullable(DS, VTLInteger.NULL);
 
-        if (ds.get() == null) {
-            return VTLObject.of((Long) null);
+        if (ds == VTLInteger.NULL || ds.get() == null) {
+            return VTLInteger.NULL;
         }
 
         return VTLNumber.of((long) Math.floor(ds.get().doubleValue()));

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLFloor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLFloor.java
@@ -43,7 +43,7 @@ public class VTLFloor extends AbstractVTLFunction<VTLInteger> {
     protected VTLInteger safeInvoke(TypeSafeArguments arguments) {
         VTLNumber ds = arguments.getNullable(DS, VTLInteger.NULL);
 
-        if (ds == VTLInteger.NULL || ds.get() == null) {
+        if (VTLInteger.NULL.equals(ds)) {
             return VTLInteger.NULL;
         }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
@@ -21,6 +21,7 @@ package no.ssb.vtl.script.functions;
  */
 
 import no.ssb.vtl.model.VTLFloat;
+import no.ssb.vtl.model.VTLInteger;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 
@@ -32,7 +33,7 @@ public class VTLRound extends AbstractVTLFunction<VTLFloat> {
 
     private static final String ARGUMENT_GREATER_THAT_ZERO = "%s must be greater than zero, was %s";
     private static final Argument<VTLNumber> DS = new Argument<>("ds", VTLNumber.class);
-    private static final Argument<VTLNumber> DECIMALS = new Argument<>("decimals", VTLNumber.class);
+    private static final Argument<VTLInteger> DECIMALS = new Argument<>("decimals", VTLInteger.class);
     private static VTLRound instance;
 
     private VTLRound() {
@@ -49,21 +50,27 @@ public class VTLRound extends AbstractVTLFunction<VTLFloat> {
     @Override
     protected VTLFloat safeInvoke(TypeSafeArguments arguments) {
 
-        VTLNumber ds = arguments.get(DS);
-        VTLNumber decimals = arguments.get(DECIMALS);
+        VTLNumber ds = arguments.getNullable(DS, VTLFloat.NULL);
+        VTLInteger decimals = arguments.get(DECIMALS);
 
-        if (ds.get() == null) {
-            return VTLObject.of((Float) null);
+        if (ds == VTLFloat.NULL || ds.get() == null) {
+            return VTLFloat.NULL;
         }
+
         if (decimals.get() == null || decimals.get().intValue() < 0) {
             throw new IllegalArgumentException(
                     format(ARGUMENT_GREATER_THAT_ZERO, DECIMALS, decimals)
             );
         }
 
-        BigDecimal bigDecimal = BigDecimal.valueOf(ds.get().doubleValue());
+        VTLFloat castValue = VTLFloat.of((Double) ds.get());
+        if (!Double.isFinite(castValue.get())) {
+            return castValue;
+        }
+
+        BigDecimal bigDecimal = BigDecimal.valueOf(castValue.get());
         BigDecimal rounded = bigDecimal.setScale(decimals.get().intValue(), BigDecimal.ROUND_HALF_UP);
 
-        return VTLObject.of(rounded.doubleValue());
+        return VTLFloat.of(rounded.doubleValue());
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/functions/VTLRound.java
@@ -53,7 +53,7 @@ public class VTLRound extends AbstractVTLFunction<VTLFloat> {
         VTLNumber ds = arguments.getNullable(DS, VTLFloat.NULL);
         VTLInteger decimals = arguments.get(DECIMALS);
 
-        if (ds == VTLFloat.NULL || ds.get() == null) {
+        if (VTLFloat.NULL.equals(ds)) {
             return VTLFloat.NULL;
         }
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLFloorTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLFloorTest.java
@@ -20,11 +20,16 @@ package no.ssb.vtl.script.functions;
  * =========================LICENSE_END==================================
  */
 
+import no.ssb.vtl.model.VTLFloat;
+import no.ssb.vtl.model.VTLInteger;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,6 +38,95 @@ public class VTLFloorTest extends AbstractVTLNumberUnaryFunctionTest {
     @Before
     public void setUp() {
         vtlUnaryFunction = VTLFloor.getInstance();
+    }
+    @Test
+    public void testInvokeWithNullNumber() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.NULL,
+                VTLObject.of((Double) null),
+                VTLObject.of((Float) null),
+                VTLFloat.of((Double) null),
+                VTLFloat.of((Float) null),
+                VTLInteger.of((Double) null),
+                VTLInteger.of((Float) null)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlUnaryFunction.invoke(
+                    Lists.newArrayList(
+                            test
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlUnaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLInteger.of((Double) null));
+            assertThat(result).isSameAs(VTLInteger.NULL);
+        }
+    }
+
+    @Test
+    public void testWithNotANumber() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.of(Double.NaN),
+                VTLObject.of(Float.NaN),
+                VTLFloat.of(Float.NaN),
+                VTLFloat.of(Double.NaN),
+                VTLInteger.of(Float.NaN),
+                VTLInteger.of(Double.NaN)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlUnaryFunction.invoke(
+                    Lists.newArrayList(
+                            test
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlUnaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLFloat.of(0));
+        }
+    }
+
+    @Test
+    public void testWithNegativeInfinity() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.of(Double.NEGATIVE_INFINITY),
+                VTLObject.of(Float.NEGATIVE_INFINITY),
+                VTLFloat.of(Float.NEGATIVE_INFINITY),
+                VTLFloat.of(Double.NEGATIVE_INFINITY)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlUnaryFunction.invoke(
+                    Lists.newArrayList(
+                            test
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlUnaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLInteger.of(Long.MIN_VALUE));
+        }
+    }
+
+    @Test
+    public void testWithPositiveInfinity() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.of(Double.POSITIVE_INFINITY),
+                VTLObject.of(Float.POSITIVE_INFINITY),
+                VTLFloat.of(Float.POSITIVE_INFINITY),
+                VTLFloat.of(Double.POSITIVE_INFINITY)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlUnaryFunction.invoke(
+                    Lists.newArrayList(
+                            test
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlUnaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLInteger.of(Long.MAX_VALUE));
+        }
     }
 
     @Test

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLRoundTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/functions/VTLRoundTest.java
@@ -20,11 +20,15 @@ package no.ssb.vtl.script.functions;
  * =========================LICENSE_END==================================
  */
 
+import no.ssb.vtl.model.VTLFloat;
+import no.ssb.vtl.model.VTLInteger;
 import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +38,83 @@ public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
     @Before
     public void setUp() {
         vtlBinaryFunction = VTLRound.getInstance();
+    }
+
+    @Test
+    public void testInvokeWithNullNumber() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.NULL,
+                VTLObject.of((Double) null),
+                VTLObject.of((Float) null),
+                VTLFloat.of((Double) null),
+                VTLFloat.of((Float) null),
+                VTLInteger.of((Double) null),
+                VTLInteger.of((Float) null)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlBinaryFunction.invoke(
+                    Lists.newArrayList(
+                            test,
+                            VTLInteger.of(0)
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlBinaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLFloat.of((Double) null));
+            assertThat(result).isSameAs(VTLFloat.NULL);
+        }
+    }
+
+    @Test
+    public void testWithNotANumber() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.of(Double.NaN),
+                VTLObject.of(Float.NaN),
+                VTLFloat.of(Float.NaN),
+                VTLFloat.of(Double.NaN),
+                VTLInteger.of(Float.NaN),
+                VTLInteger.of(Double.NaN)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlBinaryFunction.invoke(
+                    Lists.newArrayList(
+                            test,
+                            VTLInteger.of(0)
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlBinaryFunction.getVTLType());
+            assertThat(result).isEqualTo(VTLFloat.of(Double.NaN));
+        }
+    }
+
+    @Test
+    public void testWithInfinity() {
+        List<VTLObject> tests = Lists.newArrayList(
+                VTLObject.of(Double.NEGATIVE_INFINITY),
+                VTLObject.of(Float.NEGATIVE_INFINITY),
+                VTLFloat.of(Float.NEGATIVE_INFINITY),
+                VTLFloat.of(Double.NEGATIVE_INFINITY),
+
+                VTLObject.of(Double.POSITIVE_INFINITY),
+                VTLObject.of(Float.POSITIVE_INFINITY),
+                VTLFloat.of(Float.POSITIVE_INFINITY),
+                VTLFloat.of(Double.POSITIVE_INFINITY)
+        );
+
+        for (VTLObject test : tests) {
+            VTLNumber<?> result = vtlBinaryFunction.invoke(
+                    Lists.newArrayList(
+                            test,
+                            VTLInteger.of(0)
+                    )
+            );
+            assertThat(result).isNotNull();
+            assertThat(result).isInstanceOf(vtlBinaryFunction.getVTLType());
+            assertThat(result).isEqualTo(test);
+        }
     }
 
     @Test
@@ -91,11 +172,11 @@ public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
         assertThatThrownBy(() -> vtlBinaryFunction.invoke(
                 Lists.newArrayList(
                         VTLNumber.of(4),
-                        VTLNumber.of((Double) null)
+                        VTLNumber.of((Long) null)
                 )
         ))
                 .as("exception when passing null where not null is expected")
-                .hasMessage("Argument{name=decimals, type=VTLNumber} must be greater than zero, was [NULL]")
+                .hasMessage("Argument{name=decimals, type=VTLInteger} must be greater than zero, was [NULL]")
                 .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
@@ -108,7 +189,7 @@ public class VTLRoundTest extends AbstractVTLNumberBinaryFunctionTest {
                 )
         ))
                 .as("exception when passing a negative number where a positive value is expected")
-                .hasMessage("Argument{name=decimals, type=VTLNumber} must be greater than zero, was -5")
+                .hasMessage("Argument{name=decimals, type=VTLInteger} must be greater than zero, was -5")
                 .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
Non finite values are:

- Nan (0.0/0)
- +Infinity (-1.0/0)
- -Infinity (1.0/0)
- Null (missing)

When using round on non finite values the result should be returned unchanged.

- `round(0.0/0, x)` => `0.0/0`
- `round(-1.0/0, x)` => `-1.0/0`
- `round(1.0/0, x)` => `1.0/0`
- `round(null, x)` => `null`

For the floor function, since we do not support typed signature yet, the result need to be cast: 

- `floor(0.0/0, x)` => `0`
- `floor(-1.0/0, x)` => `-9223372036854775808`
- `floor(1.0/0, x)` => `9223372036854775807`
- `floor(null, x)` => `null`
