### PR TITLE
Expose collection of VTL keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Support for average aggregation function `ds := avg(ds1) group by ds1.x`
+* Expose keyword list in `VTLScriptEngine`
 
 ### Changed
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/VTLScriptEngine.java
@@ -47,6 +47,12 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.function.Consumer;
 
@@ -145,6 +151,36 @@ public class VTLScriptEngine extends AbstractScriptEngine {
         } catch (IOException | RuntimeException unknownException) {
             throw new ScriptException(unknownException);
         }
+    }
+
+    /**
+     * Returns a collection of all keywords/reserved words in VTL, divided into the following categories:
+     * - implementedVtlKeywords - implemented functions from the specifications
+     * - builtinFunctions - implemented custom functions
+     * - dataTypes - the data types used in VTL
+     * - notImplementedKeywordsAndFunctions - functions from the specifications that are not yet implemented
+     * - builtInConstants - VTL constants
+     * @return Collection of VTL keywords/reserved words
+     */
+    public Map<String, Set<String>> getVTLKeywords() {
+
+        Map<String, Set<String>> allKeywords = new HashMap<>();
+        allKeywords.put("implementedVtlKeywords", new HashSet<>(Arrays.asList("get", "put", "and", "or", "join", "inner", "outer", "cross", "on", "rename",
+                "fold", "unfold", "keep", "drop", "filter", "to", "union", "nvl", "as", "isnull", "check",
+                "hierarchy", "abs", "ceil", "date_from_string", "exp", "float_from_string", "floor", "integer_from_string",
+                "ln", "log", "mod", "nroot", "power", "round", "sqrt", "string_from_number", "substr", "trunc",
+                "ltrim", "lower", "rtrim", "upper",
+                "sum", "along", "group by")));
+        allKeywords.put("builtinFunctions", new HashSet<>(Collections.singletonList("date_from_string")));
+        allKeywords.put("dataTypes", new HashSet<>(Arrays.asList("identifier", "measure", "attribute")));
+        allKeywords.put("notImplementedKeywordsAndFunctions", new HashSet<>(Arrays.asList("exists_in", "not_exists_in", "exists_in_all", "not_exists_in_all",
+                "match_characters", "all", "any", "unique", "func_dep", "extract", "string_from_date", "current_date",
+                "listsum", "alterdataset", "eval", "lenght", "concatenation", "instr", "replace", "intersect",
+                "symdiff", "setdiff", "subscript", "transcode", "aggregate", "aggregatefunctions", "time_aggregate",
+                "fill_time_series", "flow_to_stock", "stock_to_flow", "timeshift", "calc", "attrcalc")));
+        allKeywords.put("builtinConstants", new HashSet<>(Arrays.asList("true", "false", "null")));
+
+        return allKeywords;
     }
 
     /**


### PR DESCRIPTION
Added method for exposing a collection of keywords and reserved words in VTL. Intended use is autocomplete and syntax highlighting. For now, these words are hard-coded, but a way to generate them from the grammars should be considered.