### PR TITLE
 Refactor the FoldOperation class to support attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 * Support for average aggregation function `ds := avg(ds1) group by ds1.x`
+* Attribute components are now kept when using `fold`
+* Fold optimization
 
 ### Changed
 

--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/DataPoint.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/DataPoint.java
@@ -24,47 +24,35 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DataPoint extends ArrayList<VTLObject> {
 
-    ArrayList<VTLObject> delegate;
-
     protected DataPoint(int initialCapacity) {
         super(initialCapacity);
     }
 
-    protected DataPoint() {
-    }
+    protected DataPoint() {}
 
     protected DataPoint(Collection<? extends VTLObject> c) {
         super(c);
-    }
-
-    public DataPoint(VTLObject... values) {
-        super(Arrays.asList(values));
-    }
-
-    public DataPoint(Object... values) {
-        super(Stream.of(values).map(VTLObject::of).collect(Collectors.toList()));
     }
 
     public static DataPoint create(int initialCapacity) {
         return new DataPoint(Collections.nCopies(initialCapacity, VTLObject.NULL));
     }
 
-    public static DataPoint create(List<? extends VTLObject> components) {
+    public static DataPoint create(Collection<? extends VTLObject> components) {
         return new DataPoint(components);
     }
 
     public static DataPoint create(VTLObject... values) {
-        return new DataPoint(values);
+        return new DataPoint(Arrays.asList(values));
     }
 
     public static DataPoint create(Object... values) {
-        return new DataPoint(values);
+        return new DataPoint(Stream.of(values).map(VTLObject::of).collect(Collectors.toList()));
     }
 
     @Override

--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/DataPoint.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/DataPoint.java
@@ -33,7 +33,9 @@ public class DataPoint extends ArrayList<VTLObject> {
         super(initialCapacity);
     }
 
-    protected DataPoint() {}
+    protected DataPoint() {
+        super();
+    }
 
     protected DataPoint(Collection<? extends VTLObject> c) {
         super(c);

--- a/java-vtl-model/src/test/java/no/ssb/vtl/model/DataPointTest.java
+++ b/java-vtl-model/src/test/java/no/ssb/vtl/model/DataPointTest.java
@@ -1,5 +1,25 @@
 package no.ssb.vtl.model;
 
+/*-
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
 import org.junit.Test;
 
 import java.time.Instant;

--- a/java-vtl-model/src/test/java/no/ssb/vtl/model/DataPointTest.java
+++ b/java-vtl-model/src/test/java/no/ssb/vtl/model/DataPointTest.java
@@ -1,0 +1,96 @@
+package no.ssb.vtl.model;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class DataPointTest {
+
+    @Test
+    public void testCreateWithCapacity() {
+        DataPoint point = DataPoint.create(5);
+        assertThat(point).containsExactly(
+                VTLObject.NULL,
+                VTLObject.NULL,
+                VTLObject.NULL,
+                VTLObject.NULL,
+                VTLObject.NULL
+        );
+    }
+
+    @Test
+    public void testCreateWithSource() {
+        List<VTLObject> source = Arrays.asList(
+                VTLObject.of(0L),
+                VTLObject.of(0.0D),
+                VTLObject.of(""),
+                VTLObject.of(false),
+                VTLObject.of(Instant.EPOCH),
+                VTLObject.NULL
+        );
+
+        DataPoint point = DataPoint.create(source);
+        assertThat(point).containsExactlyElementsOf(
+                source
+        );
+    }
+
+    @Test
+    public void testCreateWithoutConversion() {
+        List<VTLObject> source = Arrays.asList(
+                VTLObject.of(0L),
+                VTLObject.of(0.0D),
+                VTLObject.of(""),
+                VTLObject.of(false),
+                VTLObject.of(Instant.EPOCH),
+                VTLObject.NULL
+        );
+
+
+
+        DataPoint point = DataPoint.create(
+                VTLObject.of(0L),
+                VTLObject.of(0.0D),
+                VTLObject.of(""),
+                VTLObject.of(false),
+                VTLObject.of(Instant.EPOCH),
+                VTLObject.NULL
+        );
+
+        assertThat(point).containsExactlyElementsOf(
+                source
+        );
+    }
+
+    @Test
+    public void testCreateWithConversion() {
+        List<VTLObject> source = Arrays.asList(
+                VTLObject.of(0L),
+                VTLObject.of(0.0D),
+                VTLObject.of(""),
+                VTLObject.of(false),
+                VTLObject.of(Instant.EPOCH),
+                VTLObject.NULL
+        );
+
+
+
+        DataPoint point = DataPoint.create(
+                0L,
+                0.0D,
+                "",
+                false,
+                Instant.EPOCH,
+                null
+        );
+
+        assertThat(point).containsExactlyElementsOf(
+                source
+        );
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FoldOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FoldOperation.java
@@ -22,28 +22,25 @@ package no.ssb.vtl.script.operations;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 import no.ssb.vtl.model.AbstractUnaryDatasetOperation;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.VTLObject;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.*;
-import static no.ssb.vtl.model.Component.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static no.ssb.vtl.model.Component.Role;
 
 /**
  * Fold clause.
@@ -239,52 +236,5 @@ public class FoldOperation extends AbstractUnaryDatasetOperation {
         helper.add("identifier", dimension);
         helper.add("measure", measure);
         return helper.omitNullValues().toString();
-    }
-
-    /**
-     * Copies the values from a data point to a new structure.
-     */
-    private final class DataPointMapper implements UnaryOperator<DataPoint> {
-
-        private final int[] fromIndices;
-        private final int[] toIndices;
-        private final int size;
-
-        DataPointMapper(DataStructure from, DataStructure to) {
-            this(ImmutableSet.copyOf(from.keySet()), ImmutableSet.copyOf(to.keySet()));
-        }
-
-        DataPointMapper(
-                ImmutableSet<String> from,
-                ImmutableSet<String> to
-        ) {
-
-            ImmutableList<String> fromList = from.asList();
-            ImmutableList<String> toList = to.asList();
-
-            ArrayList<Integer> fromIndices = Lists.newArrayList();
-            ArrayList<Integer> toIndices = Lists.newArrayList();
-
-            for (String columnName : Sets.intersection(from, to)) {
-                int fromIndex = fromList.indexOf(columnName);
-                int toIndex = toList.indexOf(columnName);
-                fromIndices.add(fromIndex);
-                toIndices.add(toIndex);
-            }
-
-            this.fromIndices = Ints.toArray(fromIndices);
-            this.toIndices = Ints.toArray(toIndices);
-            this.size = to.size();
-        }
-
-
-        @Override
-        public DataPoint apply(DataPoint dataPoint) {
-            DataPoint result = DataPoint.create(size);
-            for (int i = 0; i < fromIndices.length; i++) {
-                result.set(toIndices[i], dataPoint.get(fromIndices[i]));
-            }
-            return result;
-        }
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FoldOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/FoldOperation.java
@@ -9,9 +9,9 @@ package no.ssb.vtl.script.operations;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,22 +22,24 @@ package no.ssb.vtl.script.operations;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
 import no.ssb.vtl.model.AbstractUnaryDatasetOperation;
-import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.VTLObject;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.*;
@@ -50,105 +52,174 @@ public class FoldOperation extends AbstractUnaryDatasetOperation {
 
     private final String dimension;
     private final String measure;
-    private final Set<Component> elements;
+    private final ImmutableSet<String> elements;
 
-    public FoldOperation(Dataset dataset, String dimensionReference, String measureReference, Set<Component> elements) {
-        // TODO: Introduce type here. Elements should be of the type of the Component.
+    private int[] copyIndices;
+    private int[] elementIndices;
+    private int measureIndex;
+    private int dimensionIndex;
+    private int size;
+    private String[] elementNames;
 
-        super(checkNotNull(dataset, "dataset cannot be null"));
-        checkArgument(!(this.dimension = checkNotNull(dimensionReference, "dimensionReference cannot be null")).isEmpty(),
-                "dimensionReference was empty");
-        checkArgument(!(this.measure = checkNotNull(measureReference, "measureReference cannot be null")).isEmpty(),
-                "measureReference was empty");
-        checkArgument(!(this.elements = checkNotNull(elements, "elements cannot be null")).isEmpty(),
-                "elements was empty");
+    public FoldOperation(Dataset dataset, String dimension, String measure, Set<String> elements) {
+        super(dataset);
+
+        this.elements = ImmutableSet.copyOf(elements);
+        checkArgument(!elements.isEmpty());
+
+        this.dimension = checkNotNull(dimension);
+        checkArgument(!dimension.isEmpty());
+
+        this.measure = checkNotNull(measure);
+        checkArgument(!measure.isEmpty());
+
+    }
+
+    /**
+     * Check that all of the given columns are of the same type
+     *
+     * @return the type of all the columns.
+     * @throws IllegalArgumentException if columns are not of the same type.
+     */
+    private static Class<?> checkColumnType(DataStructure structure, ImmutableSet<String> columns) {
+        ListMultimap<Class<?>, String> classes = ArrayListMultimap.create();
+        for (String element : columns) {
+            classes.put(structure.get(element).getType(), element);
+        }
+        checkArgument(
+                classes.asMap().size() == 1,
+                "all element(s) [%s] are not of the same type [%s]",
+                columns, classes
+        );
+        return classes.keys().iterator().next();
+    }
+
+    /**
+     * Checks that all of the given columns are present in the structure.
+     *
+     * @throws IllegalArgumentException if one or more columns are missing.
+     */
+    private static void checkContainsColumns(DataStructure structure, ImmutableSet<String> columns) {
+        Set<String> structureColumns = ImmutableSet.copyOf(structure.keySet());
+        checkArgument(
+                structureColumns.containsAll(columns),
+                "the element(s) [%s] were not found",
+                Sets.difference(columns, structureColumns)
+        );
+    }
+
+    /**
+     * Checks that none of the given columns have the identifier role.
+     *
+     * @throws IllegalArgumentException if one or more columns have the identifier role.
+     */
+    private static void checkNoIdentifiers(DataStructure structure, ImmutableSet<String> columns) {
+        ListMultimap<Role, String> roles = ArrayListMultimap.create();
+        for (String elements : columns) {
+            roles.put(structure.get(elements).getRole(), elements);
+        }
+        checkArgument(
+                !roles.containsKey(Role.IDENTIFIER),
+                "cannot fold identifier(s) [%s]",
+                roles.get(Role.IDENTIFIER)
+        );
     }
 
     @Override
     public DataStructure computeDataStructure() {
-        DataStructure structure = getChild().getDataStructure();
 
-        /*
-        Check that all the elements are contained inside the structure.
-            TODO: This is a constraint error.
-        */
-        checkArgument(
-                structure.values().containsAll(elements),
-                "the element(s) [%s] were not found in [%s]",
-                Sets.difference(elements, structure.keySet()), structure.keySet()
-        );
+        // In its normal form, all elements should be present in a fold operation.
+        // This should be picked up by the parser but we check once anyways.
+        DataStructure childStructure = getChild().getDataStructure();
 
-        /*
-         Checks that elements are of the same type using a Multimap.
-         */
-        ListMultimap<Class<?>, Component> classes = ArrayListMultimap.create();
-        for (Component element : elements) {
-            classes.put(element.getType(), element);
-        }
-        checkArgument(
-                classes.asMap().size() == 1,
-                "the element(s) [%s] must be of the same type, found [%s] in dataset [%s]",
-                elements, classes, structure
-        );
+        checkContainsColumns(childStructure, elements);
 
+        // All the elements should be of the same type.
+        Class<?> newType = checkColumnType(childStructure, elements);
+
+        // Cannot remove identifiers without grouping.
+        checkNoIdentifiers(childStructure, elements);
+
+        // Copy each columns that is not in elements.
+        // Putting them first optimizes the fold operation.
         DataStructure.Builder structureBuilder = DataStructure.builder();
-        for (Map.Entry<String, Component> componentEntry : structure.entrySet()) {
-            if (!elements.contains(componentEntry.getValue())) {
-                structureBuilder.put(componentEntry);
-            }
+        for (String columnName : Sets.difference(childStructure.keySet(), elements)) {
+            structureBuilder.put(columnName, childStructure.get(columnName));
         }
 
         structureBuilder.put(dimension, Role.IDENTIFIER, String.class);
-        structureBuilder.put(measure, Role.MEASURE, classes.keySet().iterator().next());
+        structureBuilder.put(measure, Role.MEASURE, newType);
+        DataStructure structure = structureBuilder.build();
 
-        return structureBuilder.build();
+        computeIndices(structure);
+
+        return structure;
+    }
+
+    /**
+     * Create indices used by the fold operation.
+     *
+     * @param structure the new structure.
+     */
+    private void computeIndices(DataStructure structure) {
+        ImmutableSet<String> originalColumns = ImmutableSet.copyOf(getChild().getDataStructure().keySet());
+        ImmutableSet<String> columns = ImmutableSet.copyOf(structure.keySet());
+
+        // Indices of the common columns.
+        copyIndices = Sets.intersection(columns, originalColumns).stream()
+                .mapToInt(originalColumns.asList()::indexOf)
+                .toArray();
+
+        elementIndices = Sets.intersection(elements, originalColumns).stream()
+                .mapToInt(originalColumns.asList()::indexOf)
+                .toArray();
+
+        elementNames = elements.asList().toArray(new String[]{});
+
+        measureIndex = columns.asList().indexOf(measure);
+        dimensionIndex = columns.asList().indexOf(dimension);
+        size = columns.size();
+    }
+
+    /**
+     * Fold a single datapoint.
+     */
+    private Stream<DataPoint> fold(DataPoint dataPoint) {
+
+        // Create a new datapoint
+        DataPoint baseDatapoint = DataPoint.create(size);
+        for (int i = 0; i < copyIndices.length; i++) {
+            baseDatapoint.set(i, dataPoint.get(copyIndices[i]));
+        }
+
+        List<DataPoint> foldedDatapoints = Lists.newArrayListWithCapacity(elements.size());
+        for (int i = 0; i < elementIndices.length; i++) {
+
+            VTLObject elementValue = dataPoint.get(elementIndices[i]);
+            if (VTLObject.NULL == elementValue || elementValue == null || elementValue.get() == null) {
+                continue;
+            }
+
+            // TODO: Still unclear from benchmark.
+            //DataPoint clone = DataPoint.create(baseDatapoint);
+            DataPoint clone = (DataPoint) baseDatapoint.clone();
+
+            clone.set(dimensionIndex, VTLObject.of(elementNames[i]));
+            clone.set(measureIndex, elementValue);
+
+            foldedDatapoints.add(clone);
+        }
+
+        return foldedDatapoints.stream();
+
     }
 
     @Override
     public Stream<DataPoint> getData() {
+        // To initialize the indices.
+        getDataStructure();
 
-        final DataStructure dataStructure = getDataStructure();
-        final DataStructure childStructure = getChild().getDataStructure();
-        final Component dimensionComponent = dataStructure.get(dimension);
-        final Component measureComponent = dataStructure.get(measure);
-
-        final List<Component> identifiers = dataStructure.entrySet()
-                .stream()
-                .map(Map.Entry::getValue)
-                .filter(Component::isIdentifier)
-                .filter(Predicate.isEqual(dimensionComponent).negate())
-                .collect(Collectors.toList());
-
-        /* Fold the values using the component in elements. */
-        return getChild().getData().flatMap(dataPoint -> {
-
-            List<DataPoint> newDataPoints = Lists.newArrayListWithExpectedSize(elements.size());
-
-            // Got through the values that will be folded.
-            Map<Component, VTLObject> dataPointMap = childStructure.asMap(dataPoint);
-            for (Component component : elements) {
-
-                VTLObject value = dataPointMap.get(component);
-                if (value == null || value == VTLObject.NULL || value.get() == null)
-                    continue;
-
-                String columnName = childStructure.getName(component);
-
-                DataPoint newDataPoint = DataPoint.create(dataStructure.size());
-                Map<Component, VTLObject> resultAsMap = dataStructure.asMap(newDataPoint);
-
-                // Put the new values
-                resultAsMap.put(dimensionComponent, VTLObject.of(columnName));
-                resultAsMap.put(measureComponent, value);
-
-                // Put the identifiers
-                for (Component identifier : identifiers) {
-                    resultAsMap.put(identifier, dataPointMap.get(identifier));
-                }
-                newDataPoints.add(newDataPoint);
-            }
-            return newDataPoints.stream();
-        });
+        return getChild().getData().flatMap(this::fold);
     }
 
     @Override
@@ -167,7 +238,53 @@ public class FoldOperation extends AbstractUnaryDatasetOperation {
         helper.addValue(elements);
         helper.add("identifier", dimension);
         helper.add("measure", measure);
-        //helper.add("structure", getDataStructure());
         return helper.omitNullValues().toString();
+    }
+
+    /**
+     * Copies the values from a data point to a new structure.
+     */
+    private final class DataPointMapper implements UnaryOperator<DataPoint> {
+
+        private final int[] fromIndices;
+        private final int[] toIndices;
+        private final int size;
+
+        DataPointMapper(DataStructure from, DataStructure to) {
+            this(ImmutableSet.copyOf(from.keySet()), ImmutableSet.copyOf(to.keySet()));
+        }
+
+        DataPointMapper(
+                ImmutableSet<String> from,
+                ImmutableSet<String> to
+        ) {
+
+            ImmutableList<String> fromList = from.asList();
+            ImmutableList<String> toList = to.asList();
+
+            ArrayList<Integer> fromIndices = Lists.newArrayList();
+            ArrayList<Integer> toIndices = Lists.newArrayList();
+
+            for (String columnName : Sets.intersection(from, to)) {
+                int fromIndex = fromList.indexOf(columnName);
+                int toIndex = toList.indexOf(columnName);
+                fromIndices.add(fromIndex);
+                toIndices.add(toIndex);
+            }
+
+            this.fromIndices = Ints.toArray(fromIndices);
+            this.toIndices = Ints.toArray(toIndices);
+            this.size = to.size();
+        }
+
+
+        @Override
+        public DataPoint apply(DataPoint dataPoint) {
+            DataPoint result = DataPoint.create(size);
+            for (int i = 0; i < fromIndices.length; i++) {
+                result.set(toIndices[i], dataPoint.get(fromIndices[i]));
+            }
+            return result;
+        }
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/FoldVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/FoldVisitor.java
@@ -21,7 +21,6 @@ package no.ssb.vtl.script.visitors.join;
  */
 
 import com.google.common.collect.ImmutableSet;
-import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.parser.VTLParser;
 import no.ssb.vtl.script.operations.FoldOperation;
@@ -47,8 +46,9 @@ public class FoldVisitor extends VTLDatasetExpressionVisitor<FoldOperation> {
         String dimension = ctx.dimension.getText();
         String measure = ctx.measure.getText();
 
-        Set<Component> elements = ctx.variableExpression().stream()
+        Set<String> elements = ctx.variableExpression().stream()
                 .map(componentVisitor::visit)
+                .map(dataset.getDataStructure()::getName)
                 .collect(ImmutableSet.toImmutableSet());
 
         return new FoldOperation(dataset, dimension, measure, elements);

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
@@ -1,0 +1,54 @@
+package no.ssb.vtl.script.operations;
+
+import com.google.common.collect.ImmutableSet;
+import no.ssb.vtl.model.DataStructure;
+import no.ssb.vtl.model.StaticDataset;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static no.ssb.vtl.model.Component.Role.ATTRIBUTE;
+import static no.ssb.vtl.model.Component.Role.IDENTIFIER;
+import static no.ssb.vtl.model.Component.Role.MEASURE;
+
+public class FoldOperationBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class FoldState {
+        private StaticDataset dataset;
+        private FoldOperation clause;
+
+        @Setup
+        public void setup() {
+            dataset = StaticDataset.create()
+                    .addComponent("id1", IDENTIFIER, String.class)
+                    .addComponent("id2", IDENTIFIER, String.class)
+                    .addComponent("measure1", MEASURE, String.class)
+                    .addComponent("measure2", MEASURE, String.class)
+                    .addComponent("attribute", ATTRIBUTE, String.class)
+
+                    .addPoints("id1-1", "id2-1", "measure1-1", "measure2-1", "attribute1-1")
+                    .addPoints("id1-1", "id2-2", null, "measure2-2", "attribute1-2")
+                    .addPoints("id1-2", "id2-1", "measure1-3", null, "attribute1-3")
+                    .addPoints("id1-2", "id2-2", "measure1-4", "measure2-4", null)
+                    .addPoints("id1-3", "id2-1", null, null, null)
+
+                    .build();
+
+            DataStructure structure = dataset.getDataStructure();
+            clause = new FoldOperation(
+                    dataset,
+                    "newId",
+                    "newMeasure",
+                    ImmutableSet.of(structure.get("measure1"), structure.get("measure2"))
+            );
+        }
+    }
+
+    @Benchmark
+    public void foldBenchmark(FoldState state, Blackhole blackhole) {
+        state.clause.getData().forEach(blackhole::consume);
+    }
+}

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
@@ -82,7 +82,7 @@ public class FoldOperationBenchmark {
                     dataset,
                     "newId",
                     "newMeasure",
-                    ImmutableSet.of(structure.get("measure1"), structure.get("measure2"))
+                    ImmutableSet.of("measure1", "measure2")
             );
 
             spliterator = clause.getData().spliterator();

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationBenchmark.java
@@ -1,5 +1,25 @@
 package no.ssb.vtl.script.operations;
 
+/*-
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import no.ssb.vtl.model.DataPoint;

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
@@ -75,45 +74,31 @@ public class FoldOperationTest extends RandomizedTest {
                 "element2", MEASURE, String.class
         );
 
-        Set<Component> validElements = Sets.newHashSet(structure.values());
+        Set<String> validElements = Sets.newHashSet(structure.keySet());
         Dataset dataset = mock(Dataset.class);
 
         try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
 
             softly.assertThatThrownBy(() -> new FoldOperation(null, validDimensionReference, validMeasureReference, validElements))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("dataset")
-                    .hasMessageContaining("null");
+                    .isInstanceOf(NullPointerException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, null, validMeasureReference, validElements))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("dimensionReference")
-                    .hasMessageContaining("null");
+                    .isInstanceOf(NullPointerException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, validDimensionReference, null, validElements))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("measureReference")
-                    .hasMessageContaining("null");
+                    .isInstanceOf(NullPointerException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, validDimensionReference, validMeasureReference, null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("elements")
-                    .hasMessageContaining("null");
+                    .isInstanceOf(NullPointerException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, "", validMeasureReference, validElements))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("dimensionReference")
-                    .hasMessageContaining("empty");
+                    .isInstanceOf(IllegalArgumentException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, validDimensionReference, "", validElements))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("measureReference")
-                    .hasMessageContaining("empty");
+                    .isInstanceOf(IllegalArgumentException.class);
 
             softly.assertThatThrownBy(() -> new FoldOperation(dataset, validDimensionReference, validMeasureReference, Collections.emptySet()))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("elements")
-                    .hasMessageContaining("empty");
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -137,23 +122,22 @@ public class FoldOperationTest extends RandomizedTest {
                 "m3", MEASURE, Instant.class
         );
 
-        Set<Component> validElements = Sets.newHashSet(
-                structure.get("m1"),
-                structure.get("m2"),
-                structure.get("m3")
+        Set<String> validElements = Sets.newHashSet(
+                "m1",
+                "m2",
+                "m3"
         );
 
-        Set<Component> invalidElements = Sets.newHashSet(
-                structure.get("m1"),
-                structure.get("m2"),
-                structure.get("m3"),
-                wrongTypesDataset.get("m1")
+        Set<String> invalidElements = Sets.newHashSet(
+                "m1",
+                "m2",
+                "m3",
+                "m4"
         );
 
-        Set<Component> wrongTypesElements = Sets.newHashSet(
-                wrongTypesDataset.values()
+        Set<String> wrongTypesElements = Sets.newHashSet(
+                wrongTypesDataset.keySet()
         );
-
 
         when(dataset.getDataStructure()).thenReturn(structure);
         when(invalidDataset.getDataStructure()).thenReturn(wrongTypesDataset);
@@ -164,7 +148,7 @@ public class FoldOperationTest extends RandomizedTest {
                 clause.getDataStructure();
             })
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("m1")
+                    .hasMessageContaining("m4")
                     .hasMessageContaining("not found");
 
             softly.assertThatThrownBy(() -> {
@@ -180,7 +164,7 @@ public class FoldOperationTest extends RandomizedTest {
     }
 
     @Test
-    @Repeat(iterations = 1)
+    @Repeat(iterations = 10)
     public void testFold() {
 
         DatasetCloseWatcher dataset = DatasetCloseWatcher.wrap(StaticDataset.create()
@@ -201,13 +185,11 @@ public class FoldOperationTest extends RandomizedTest {
 
         // Collections.shuffle(data, new Random(randomLong()));
 
-        DataStructure structure = dataset.getDataStructure();
-
         // Randomly shuffle the measures
-        ArrayList<Component> elements = Lists.newArrayList(
-                structure.get("measure2"),
-                structure.get("measure1"),
-                structure.get("measure3")
+        ArrayList<String> elements = Lists.newArrayList(
+                "measure2",
+                "measure1",
+                "measure3"
         );
         Collections.shuffle(elements, new Random(randomLong()));
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/FoldOperationTest.java
@@ -26,7 +26,12 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import no.ssb.vtl.model.*;
+import no.ssb.vtl.model.Component;
+import no.ssb.vtl.model.DataPoint;
+import no.ssb.vtl.model.DataStructure;
+import no.ssb.vtl.model.Dataset;
+import no.ssb.vtl.model.Order;
+import no.ssb.vtl.model.StaticDataset;
 import no.ssb.vtl.script.support.DatasetCloseWatcher;
 import org.assertj.core.api.AutoCloseableSoftAssertions;
 import org.junit.Test;
@@ -40,9 +45,12 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.*;
-import static no.ssb.vtl.model.Component.Role.*;
-import static org.mockito.Mockito.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static no.ssb.vtl.model.Component.Role.ATTRIBUTE;
+import static no.ssb.vtl.model.Component.Role.IDENTIFIER;
+import static no.ssb.vtl.model.Component.Role.MEASURE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FoldOperationTest extends RandomizedTest {
 
@@ -172,21 +180,22 @@ public class FoldOperationTest extends RandomizedTest {
     }
 
     @Test
-    @Repeat(iterations = 10)
+    @Repeat(iterations = 1)
     public void testFold() {
 
         DatasetCloseWatcher dataset = DatasetCloseWatcher.wrap(StaticDataset.create()
                 .addComponent("id1", IDENTIFIER, String.class)
-                .addComponent("id2", IDENTIFIER, String.class ) // TODO: What if the dataset already contains id2?
+                .addComponent("id2", IDENTIFIER, String.class )
                 .addComponent("measure1", MEASURE, String.class)
-                .addComponent("measure2", MEASURE, String.class) // TODO: Okay with attributes?
-                .addComponent("attribute1", ATTRIBUTE, String.class)
+                .addComponent("measure2", MEASURE, String.class)
+                .addComponent("measure3", MEASURE, String.class)
+                .addComponent("attribute", ATTRIBUTE, String.class)
 
-                .addPoints("id1-1", "id2-1", "measure1-1", "measure2-1", "attribute1-1")
-                .addPoints("id1-1", "id2-2", null, "measure2-2", "attribute1-2")
-                .addPoints("id1-2", "id2-1", "measure1-3", null, "attribute1-3")
-                .addPoints("id1-2", "id2-2", "measure1-4", "measure2-4", null)
-                .addPoints("id1-3", "id2-1", null, null, null)
+                .addPoints("id1-1", "id2-1", "measure1-1", "measure2-1", "measure3-1", "attribute1-1")
+                .addPoints("id1-1", "id2-2", null,         "measure2-2", "measure3-2", "attribute1-2")
+                .addPoints("id1-2", "id2-1", "measure1-3", null,         "measure3-3", "attribute1-3")
+                .addPoints("id1-2", "id2-2", "measure1-4", "measure2-4", null,         "attribute1-4")
+                .addPoints("id1-3", "id2-1", "measure1-5", "measure2-5", "measure3-5",         null)
 
                 .build());
 
@@ -198,7 +207,7 @@ public class FoldOperationTest extends RandomizedTest {
         ArrayList<Component> elements = Lists.newArrayList(
                 structure.get("measure2"),
                 structure.get("measure1"),
-                structure.get("attribute1")
+                structure.get("measure3")
         );
         Collections.shuffle(elements, new Random(randomLong()));
 
@@ -212,7 +221,7 @@ public class FoldOperationTest extends RandomizedTest {
             );
 
             softly.assertThat(clause.getDataStructure()).containsOnlyKeys(
-                    "id1", "id2", "newId", "newMeasure"
+                    "id1", "id2", "newId", "newMeasure", "attribute"
             );
 
             // Need to sort back before assert.
@@ -223,23 +232,27 @@ public class FoldOperationTest extends RandomizedTest {
                     .build();
 
             Stream<DataPoint> stream = clause.getData();
-            softly.assertThat(stream.sorted(order)).flatExtracting(input -> input).extracting(VTLObject::get)
+            softly.assertThat(stream.sorted(order))
                     .containsExactly(
-                            "id1-1", "id2-1", "attribute1", "attribute1-1",
-                            "id1-1", "id2-1", "measure1", "measure1-1",
-                            "id1-1", "id2-1", "measure2", "measure2-1",
+                            DataPoint.create("id1-1", "id2-1", "attribute1-1", "measure1", "measure1-1"),
+                            DataPoint.create("id1-1", "id2-1", "attribute1-1", "measure2", "measure2-1"),
+                            DataPoint.create("id1-1", "id2-1", "attribute1-1", "measure3", "measure3-1"),
 
-                            "id1-1", "id2-2", "attribute1", "attribute1-2",
-                            // null
-                            "id1-1", "id2-2", "measure2", "measure2-2",
+                            // DataPoint.create("id1-1", "id2-2", null, "measure1", "measure1-2"),
+                            DataPoint.create("id1-1", "id2-2", "attribute1-2", "measure2", "measure2-2"),
+                            DataPoint.create("id1-1", "id2-2", "attribute1-2", "measure3", "measure3-2"),
 
-                            "id1-2", "id2-1", "attribute1", "attribute1-3",
-                            "id1-2", "id2-1", "measure1", "measure1-3",
-                            // null
+                            DataPoint.create("id1-2", "id2-1", "attribute1-3", "measure1", "measure1-3"),
+                            // DataPoint.create("id1-2", "id2-1", null, "measure2", "measure2-3"),
+                            DataPoint.create("id1-2", "id2-1", "attribute1-3", "measure3", "measure3-3"),
 
-                            // null
-                            "id1-2", "id2-2", "measure1", "measure1-4",
-                            "id1-2", "id2-2", "measure2", "measure2-4"
+                            DataPoint.create("id1-2", "id2-2", "attribute1-4", "measure1", "measure1-4"),
+                            DataPoint.create("id1-2", "id2-2", "attribute1-4", "measure2", "measure2-4"),
+                            //DataPoint.create("id1-2", "id2-2", null, "measure3", "measure3-4"),
+
+                            DataPoint.create("id1-3", "id2-1", null, "measure1", "measure1-5"),
+                            DataPoint.create("id1-3", "id2-1", null, "measure2", "measure2-5"),
+                            DataPoint.create("id1-3", "id2-1", null, "measure3", "measure3-5")
                     );
             stream.close();
 

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/hierarchy/HierarchyOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/hierarchy/HierarchyOperationTest.java
@@ -42,7 +42,6 @@ import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.Order;
-import no.ssb.vtl.model.VTLNumber;
 import no.ssb.vtl.model.VTLObject;
 import no.ssb.vtl.script.support.DatasetCloseWatcher;
 import no.ssb.vtl.script.support.VTLPrintStream;
@@ -267,13 +266,13 @@ public class HierarchyOperationTest extends RandomizedTest {
             }
         }
         //Add point with null value in MC
-        data.add(new DataPoint(
+        data.add(DataPoint.create(
                 Year.of(2006).atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC),
                 "Luxembourg", VTLObject.of((Object)null), VTLObject.of((Object)null)));
-        data.add(new DataPoint(
+        data.add(DataPoint.create(
                 Year.of(2006).atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC),
                 "Holland", VTLObject.of(2006), VTLObject.of(-2006)));
-        data.add(new DataPoint(
+        data.add(DataPoint.create(
                 Year.of(2007).atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC),
                 "Luxembourg", VTLObject.of((Object)null), VTLObject.of((Object)null)));
 

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
             <scope>test</scope>
@@ -533,6 +545,20 @@
                 <groupId>com.carrotsearch.randomizedtesting</groupId>
                 <artifactId>randomizedtesting-runner</artifactId>
                 <version>2.5.0</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>1.19</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>1.19</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Add support for attributes that are not part of the elements of a fold operation. Before this the attributes were simply dropped. 

The `FoldOperation` now checks that the folded elements are not identifier columns since it would compromise uniqueness of the resulting data set.

The refactoring includes an optimization of the fold logic. The previous
version used a map "view", adding object creation overhead for each row that
impacted the performances significantly. A quick benchmark reveals a 220
percent improvement in ops/s.

Before;  4661195.804 ±(99.9%) 116107.200 ops/s [Average]
Now;    10299985.786 ±(99.9%)  96693.333 ops/s [Average]