### PR TITLE
Fix incorrect key extraction in InnerJoinOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
+## 0.1.10-2 - 2018-09-04
+
 ### Changed
+
+* Fix invalid key extraction in InnerJoinOperation
 
 ## 0.1.10-1 - 2018-08-31
 

--- a/java-vtl-coverage/pom.xml
+++ b/java-vtl-coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-1</version>
+        <version>0.1.10-2</version>
     </parent>
 
     <artifactId>java-vtl-coverage</artifactId>

--- a/java-vtl-model/pom.xml
+++ b/java-vtl-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-1</version>
+        <version>0.1.10-2</version>
     </parent>
 
     <artifactId>java-vtl-model</artifactId>

--- a/java-vtl-parser/pom.xml
+++ b/java-vtl-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-1</version>
+        <version>0.1.10-2</version>
     </parent>
 
     <artifactId>java-vtl-parser</artifactId>

--- a/java-vtl-script/pom.xml
+++ b/java-vtl-script/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>java-vtl-parent</artifactId>
         <groupId>no.ssb.vtl</groupId>
-        <version>0.1.10-1</version>
+        <version>0.1.10-2</version>
     </parent>
 
     <artifactId>java-vtl-script</artifactId>

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/JoinKeyExtractor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/JoinKeyExtractor.java
@@ -57,7 +57,7 @@ public class JoinKeyExtractor implements UnaryOperator<DataPoint> {
     }
 
 
-    private JoinKeyExtractor(
+    public JoinKeyExtractor(
             DataStructure childStructure,
             Order order,
             Function<Component, Component> mapper

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinOperationTest.java
@@ -58,6 +58,45 @@ import static org.assertj.core.api.Assertions.entry;
 public class InnerJoinOperationTest extends RandomizedTest {
 
     @Test
+    public void testInvalidKeyExtractorBug() {
+        // When the position of the first dataset's identifiers does not match those of
+        // the subsequent datasets the key extractor can return the wrong objects.
+        StaticDataset t1 = StaticDataset.create()
+                .addComponent("ms1", MEASURE, Long.class)
+                .addComponent("id1", IDENTIFIER, String.class)
+                .addComponent("id2", IDENTIFIER, String.class)
+                .addPoints(4L, "1", "2")
+                .build();
+
+        StaticDataset t2 = StaticDataset.create()
+                .addComponent("ms2", MEASURE, Long.class)
+                .addComponent("ms3", MEASURE, Long.class)
+                .addComponent("id1", IDENTIFIER, String.class)
+                .addComponent("id2", IDENTIFIER, String.class)
+                .addPoints(8L, 16L, "1", "2")
+                .build();
+
+        StaticDataset t3 = StaticDataset.create()
+                .addComponent("ms2", MEASURE, Long.class)
+                .addComponent("ms4", MEASURE, Long.class)
+                .addComponent("id1", IDENTIFIER, String.class)
+                .addComponent("id2", IDENTIFIER, String.class)
+                .addPoints(32L, 64L, "1", "2")
+                .build();
+
+        InnerJoinOperation result = new InnerJoinOperation(ImmutableMap.of(
+                "t1", t1,
+                "t2", t2,
+                "t3", t3
+        ));
+
+        assertThat(result.getData()).containsExactly(
+                DataPoint.create(4, "1", "2", 8, 16, 32, 64)
+        );
+
+    }
+
+    @Test
     @Seed("9DC9B02FF9A216E4")
     public void testRegression() throws Exception {
         //D0E9B354FC19C5A:9DC9B02FF9A216E4

--- a/java-vtl-test/pom.xml
+++ b/java-vtl-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-1</version>
+        <version>0.1.10-2</version>
     </parent>
 
     <artifactId>java-vtl-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>no.ssb.vtl</groupId>
     <artifactId>java-vtl-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.10-1</version>
+    <version>0.1.10-2</version>
 
     <modules>
         <module>java-vtl-model</module>


### PR DESCRIPTION
The inner join on more than two datasets is implemented by recursively joining every dataset after the second with the previous join. Such as:

```
t1 \__..._ result
t2 / /  /
t3 _/  /
...   /
tn __/
```

The first dataset normalize the DataPoint to the final structure to make each merge operation easy, but the first data structure was incorrectly assumed to be the same (that is, the identifier of t1 and t2 to be at the same place).

This worked because the serialization in the connector orders the column with the identifiers first, but this assumption is wrong for other connectors.