### PR TITLE
Support for escaped variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+### Changed
+
+* Add support for escaped variable names
+
 ## 0.1.10-2 - 2018-09-04
 
 ### Changed

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AbstractVariableVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AbstractVariableVisitor.java
@@ -50,7 +50,7 @@ public abstract class AbstractVariableVisitor<T> extends VTLBaseVisitor<T> {
         throw new ContextualRuntimeException(format("undefined variable %s", ctx.getText()), ctx);
     }
 
-    private static String unEscape(String identifier) {
+    public static String unEscape(String identifier) {
         // Unescape.
         if (identifier.startsWith("\'") && identifier.endsWith("\'")) {
             return identifier.substring(1, identifier.length() - 1);

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AssignmentVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/AssignmentVisitor.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static no.ssb.vtl.script.visitors.AbstractVariableVisitor.unEscape;
 
 /**
  * Assignment visitor.
@@ -68,7 +69,7 @@ public class AssignmentVisitor extends VTLBaseVisitor<Object> {
     
     @Override
     public Object visitAssignment(VTLParser.AssignmentContext ctx) {
-        String name = ctx.variable().getText();
+        String name = unEscape(ctx.variable().getText());
         Object value;
         if (ctx.datasetExpression() != null) {
             value = visit(ctx.datasetExpression());

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/FoldVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/FoldVisitor.java
@@ -30,6 +30,7 @@ import no.ssb.vtl.script.visitors.VTLDatasetExpressionVisitor;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static no.ssb.vtl.script.visitors.AbstractVariableVisitor.unEscape;
 
 public class FoldVisitor extends VTLDatasetExpressionVisitor<FoldOperation> {
 
@@ -43,8 +44,8 @@ public class FoldVisitor extends VTLDatasetExpressionVisitor<FoldOperation> {
 
     @Override
     public FoldOperation visitJoinFoldExpression(VTLParser.JoinFoldExpressionContext ctx) {
-        String dimension = ctx.dimension.getText();
-        String measure = ctx.measure.getText();
+        String dimension = unEscape(ctx.dimension.getText());
+        String measure = unEscape(ctx.measure.getText());
 
         Set<String> elements = ctx.variableExpression().stream()
                 .map(componentVisitor::visit)

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinBodyVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinBodyVisitor.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Optional.ofNullable;
+import static no.ssb.vtl.script.visitors.AbstractVariableVisitor.unEscape;
 
 public class JoinBodyVisitor extends VTLBaseVisitor<Dataset> {
 
@@ -87,7 +88,7 @@ public class JoinBodyVisitor extends VTLBaseVisitor<Dataset> {
         VTLExpression expression = expressionVisitor.visit(joinAssignment.expression());
 
         // Calculate name
-        String componentName = joinAssignment.variable().getText();
+        String componentName = unEscape(joinAssignment.variable().getText());
 
 
         JoinAssignment result = new JoinAssignment(

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -145,6 +145,102 @@ public class VTLScriptEngineTest {
     }
 
     @Test
+    public void testEscapedAssignment() throws Exception {
+
+        bindings.put("ds1", dataset);
+        engine.eval("'1escapedDs2' := ds1");
+
+        assertThat(bindings).containsKey("1escapedDs2");
+        Object ds2 = bindings.get("ds2");
+        assertThat(ds2).isInstanceOf(Dataset.class);
+        assertThat(ds2).isSameAs(dataset);
+
+    }
+
+    @Test
+    public void testEscapedExpression() throws Exception {
+
+        bindings.put("123escaped-ds1", dataset);
+        engine.eval("ds2 := '123escaped-ds1'");
+
+        assertThat(bindings).containsKey("1escapedDs2");
+        Object ds2 = bindings.get("ds2");
+        assertThat(ds2).isInstanceOf(Dataset.class);
+        assertThat(ds2).isSameAs(dataset);
+
+    }
+
+    @Test
+    public void testJoinAssignment() throws ScriptException {
+        Dataset simpleDataset = StaticDataset.create()
+                .addComponent("id", Role.IDENTIFIER, String.class)
+                .addComponent("me", Role.MEASURE, Long.class)
+                .addPoints("id", 0L)
+                .build();
+
+        bindings.put("ds", simpleDataset);
+        engine.eval("/* join assignment */" +
+                "res := [ds] {" +
+                "   assigned := me + 1" +
+                "}");
+
+        assertThat(bindings).containsKey("res");
+        Object res = bindings.get("res");
+        assertThat(res).isInstanceOf(Dataset.class);
+        assertThat(((Dataset)res).getDataStructure()).containsKeys("assigned");
+        assertThat(((Dataset) res).getData()).containsExactly(
+                DataPoint.create("id", 0L, +1L)
+        );
+    }
+
+    @Test
+    public void testJoinEscapedAssignment() throws ScriptException {
+
+        Dataset simpleDataset = StaticDataset.create()
+                .addComponent("id", Role.IDENTIFIER, String.class)
+                .addComponent("me", Role.MEASURE, Long.class)
+                .addPoints("id", 0L)
+                .build();
+
+        bindings.put("ds", simpleDataset);
+        engine.eval("/* join assignment */" +
+                "res := [ds] {" +
+                "   '123escaped-assigned' := me + 1" +
+                "}");
+
+        assertThat(bindings).containsKey("res");
+        Object res = bindings.get("res");
+        assertThat(res).isInstanceOf(Dataset.class);
+        assertThat(((Dataset)res).getDataStructure()).containsKeys("123escaped-assigned");
+        assertThat(((Dataset) res).getData()).containsExactly(
+                DataPoint.create("id", 0L, 1L)
+        );
+    }
+
+    @Test
+    public void testJoinEscapedExpression() throws ScriptException {
+        Dataset simpleDataset = StaticDataset.create()
+                .addComponent("id", Role.IDENTIFIER, String.class)
+                .addComponent("123escaped-me", Role.MEASURE, Long.class)
+                .addPoints("id", 0L)
+                .build();
+
+        bindings.put("ds", simpleDataset);
+        engine.eval("/* join assignment */" +
+                "res := [ds] {" +
+                "   assigned := '123escaped-me' + 1" +
+                "}");
+
+        assertThat(bindings).containsKey("res");
+        Object res = bindings.get("res");
+        assertThat(res).isInstanceOf(Dataset.class);
+        assertThat(((Dataset)res).getDataStructure()).containsKeys("assigned");
+        assertThat(((Dataset) res).getData()).containsExactly(
+                DataPoint.create("id", 0L, 1L)
+        );
+    }
+
+    @Test
     public void testAssignmentLiterals() throws Exception {
 
         StaticDataset dataset = StaticDataset.create()

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -151,7 +151,7 @@ public class VTLScriptEngineTest {
         engine.eval("'1escapedDs2' := ds1");
 
         assertThat(bindings).containsKey("1escapedDs2");
-        Object ds2 = bindings.get("ds2");
+        Object ds2 = bindings.get("1escapedDs2");
         assertThat(ds2).isInstanceOf(Dataset.class);
         assertThat(ds2).isSameAs(dataset);
 
@@ -163,7 +163,7 @@ public class VTLScriptEngineTest {
         bindings.put("123escaped-ds1", dataset);
         engine.eval("ds2 := '123escaped-ds1'");
 
-        assertThat(bindings).containsKey("1escapedDs2");
+        assertThat(bindings).containsKey("ds2");
         Object ds2 = bindings.get("ds2");
         assertThat(ds2).isInstanceOf(Dataset.class);
         assertThat(ds2).isSameAs(dataset);

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -433,7 +433,7 @@ public class VTLScriptEngineTest {
                 .addComponent("id1", Role.IDENTIFIER, String.class)
                 .addComponent("m1", Role.MEASURE, Long.class)
                 .addComponent("m2", Role.MEASURE, Long.class)
-                .addComponent("m3", Role.MEASURE, Long.class)
+                .addComponent("123-m3", Role.MEASURE, Long.class)
 
                 .addPoints("1", 101L, 102L, 103L)
                 .addPoints("2", 201L, 202L, 203L)
@@ -443,8 +443,8 @@ public class VTLScriptEngineTest {
 
         bindings.put("ds1", ds1);
         engine.eval("ds2 := [ds1] {" +
-                "  total := ds1.m1 + ds1.m2 + ds1.m3," +
-                "  fold ds1.m1, ds1.m2, ds1.m3, total to type, value" +
+                "  total := ds1.m1 + ds1.m2 + ds1.'123-m3'," +
+                "  fold ds1.m1, m2, ds1.'123-m3', total to type, '123-value'" +
                 "}"
         );
 
@@ -454,7 +454,7 @@ public class VTLScriptEngineTest {
         assertThat(ds2.getDataStructure().getRoles()).containsOnly(
                 entry("id1", Role.IDENTIFIER),
                 entry("type", Role.IDENTIFIER),
-                entry("value", Role.MEASURE)
+                entry("123-value", Role.MEASURE)
         );
 
         assertThat(ds2.getData()).flatExtracting(input -> input)
@@ -462,17 +462,17 @@ public class VTLScriptEngineTest {
                 .containsExactly(
                         "1", "m1", 101L,
                         "1", "m2", 102L,
-                        "1", "m3", 103L,
+                        "1", "123-m3", 103L,
                         "1", "total", 101L + 102L + 103L,
 
                         "2", "m1", 201L,
                         "2", "m2", 202L,
-                        "2", "m3", 203L,
+                        "2", "123-m3", 203L,
                         "2", "total", 201L + 202L + 203L,
 
                         "3", "m1", 301L,
                         "3", "m2", 302L,
-                        "3", "m3", 303L,
+                        "3", "123-m3", 303L,
                         "3", "total", 301L + 302L + 303L
                 );
     }


### PR DESCRIPTION
Add support for escaped (surrounded by ') variables.

```
'123@' := "escaped"
var := '123@'
ds1 := [ds2] {
    '123@' := "escaped",
    fold var1, '123@' to '123@type', value
}
```
