### PR TITLE
Throw error on undefined functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Throw ContextualRuntimeException in user function visitor 
+
 ## 0.1.10-2 - 2018-09-04
 
 ### Changed

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/ExpressionVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/ExpressionVisitor.java
@@ -259,7 +259,12 @@ public class ExpressionVisitor extends VTLBaseVisitor<VTLExpression> {
 
     @Override
     public VTLExpression visitUserFunctionCall(VTLParser.UserFunctionCallContext ctx) {
-        throw new IllegalArgumentException("undefined function " +  ctx.functionName.getText());
+        // TODO: look for function. Check signature.
+
+        throw new ContextualRuntimeException(
+                "undefined function " + ctx.functionName.getText(),
+                ctx
+        );
     }
 
     @Override

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLErrorsTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLErrorsTest.java
@@ -44,4 +44,21 @@ public class VTLErrorsTest {
                 .hasMessageContaining("missing ','")
                 .hasMessageContaining("missing argument(s): decimals");
     }
+
+    @Test
+    public void testUndefinedFunction() {
+
+        // @formatter:off
+        String script = "variable := notReallyAFunction(1,2,3)";
+        // @formatter:on
+
+        VTLScriptEngine engine = new VTLScriptEngine();
+        assertThatThrownBy(() -> {
+            engine.eval(script);
+        })
+                .as("engine exception")
+                .isInstanceOf(VTLCompileException.class)
+                .hasMessageContaining("undefined function")
+                .hasMessageContaining("notReallyAFunction");
+    }
 }


### PR DESCRIPTION
Using undefined function now fails appropriately. 

``` 
test := notAFunction(1,2,3)
```
yields `undefined function notAFunction in <unknown> at line 1 and column 8`
