### PR TITLE
Inner join fails when the requested order does not include all the common identifiers

### DIFF
--- a/java-vtl-coverage/pom.xml
+++ b/java-vtl-coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-2</version>
+        <version>0.1.10-3</version>
     </parent>
 
     <artifactId>java-vtl-coverage</artifactId>

--- a/java-vtl-model/pom.xml
+++ b/java-vtl-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-2</version>
+        <version>0.1.10-3</version>
     </parent>
 
     <artifactId>java-vtl-model</artifactId>

--- a/java-vtl-parser/pom.xml
+++ b/java-vtl-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-2</version>
+        <version>0.1.10-3</version>
     </parent>
 
     <artifactId>java-vtl-parser</artifactId>

--- a/java-vtl-script/pom.xml
+++ b/java-vtl-script/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>java-vtl-parent</artifactId>
         <groupId>no.ssb.vtl</groupId>
-        <version>0.1.10-2</version>
+        <version>0.1.10-3</version>
     </parent>
 
     <artifactId>java-vtl-script</artifactId>

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
@@ -21,7 +21,6 @@ package no.ssb.vtl.script.operations.join;
  */
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.DataPoint;
@@ -200,9 +199,8 @@ public class InnerJoinOperation extends AbstractJoinOperation {
         }
 
         Order.Builder predicateBuilder = Order.create(fakeStructure.build());
-        Sets.SetView<Component> filteredRequestedOrder = Sets.intersection(requestedOrder.keySet(), commonIdentifiers);
-        for (Component component : filteredRequestedOrder) {
-            predicateBuilder.put(component, requestedOrder.get(component));
+        for (Component component : commonIdentifiers) {
+            predicateBuilder.put(component, requestedOrder.getOrDefault(component, Order.Direction.ASC));
         }
         return predicateBuilder.build();
     }

--- a/java-vtl-test/pom.xml
+++ b/java-vtl-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.ssb.vtl</groupId>
         <artifactId>java-vtl-parent</artifactId>
-        <version>0.1.10-2</version>
+        <version>0.1.10-3</version>
     </parent>
 
     <artifactId>java-vtl-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>no.ssb.vtl</groupId>
     <artifactId>java-vtl-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.10-2</version>
+    <version>0.1.10-3</version>
 
     <modules>
         <module>java-vtl-model</module>


### PR DESCRIPTION
The method computePredicate() is supposed to return an Order object that compares only the common identifiers of the InnerJoin operation. This was only true when all the common identifiers were requested by the original Order object (#97). 

It is unlikely this bug affect the results since the default order includes all the identifiers by defaults.