### PR TITLE
Filter propagation

### DIFF
--- a/java-vtl-model/src/main/java/no/ssb/vtl/model/Dataset.java
+++ b/java-vtl-model/src/main/java/no/ssb/vtl/model/Dataset.java
@@ -40,12 +40,11 @@ package no.ssb.vtl.model;
  * #L%
  */
 
-import com.google.common.base.Predicate;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**


### PR DESCRIPTION
# WIP

The filter propagation pushes back filters to avoids passing data to an operation that we know the operations further ahead will filter out.

The filter passed back the operation tree sometimes can fail and this must be communicated back so that the current operation can apply the filter itself. A way to do that can be to use a custom Spliterator characteristic.

- [ ] Filter
  Push filter back to the operation tree as is. Received filter is added. 
- [ ] InnerJoin
  Converts the filter and push back to the corresponding child.
- [ ] OuterJoin
  Converts the filter and push back the corresponding child. Null checks might need to be handled differently.
- [ ] CrossJoin
  Converts the filter and push back the corresponding child.
- [ ] Aggregate
  Aggregate values must be removed from
- [ ] Hierarchy
- [ ] Join assignment
  Can propagate if the assignment is simple
- [ ] Union
  Push on all children
- [ ] If then else
  Possible to express as a filter if expressions are simple
- [ ] Fold
  Not sure yet
- [ ] Unfold
  Not sure yet
- [ ] Keep
  Not applicable
- [ ] Drop
  Not applicable