### PR TITLE
Refactored inner and outer join

### DIFF
--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/AbstractJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/AbstractJoinOperation.java
@@ -68,7 +68,6 @@ public abstract class AbstractJoinOperation extends AbstractDatasetOperation imp
     private static final String ERROR_NO_COMMON_IDENTIFIERS = "could not find common identifiers in the datasets %s";
     protected final ImmutableMap<String, Dataset> datasets;
     private final ImmutableMap<String, Component> commonIdentifiers;
-    private final Set<String> commonIdentifierNames;
     // Contains name mappings for all datasets
     private final Table<String, String, String> columnMapping;
 
@@ -111,8 +110,7 @@ public abstract class AbstractJoinOperation extends AbstractDatasetOperation imp
                 ERROR_INCOMPATIBLE_TYPES,
                 String.join(", ", typeMismatches)
         );
-        this.commonIdentifierNames = commonIdentifiers.keySet();
-        this.columnMapping = getColumnMapping(namedDatasets, commonIdentifierNames);
+        this.columnMapping = getColumnMapping(namedDatasets, commonIdentifiers.keySet());
 
         this.joinScope = createJoinScope(namedDatasets, commonIdentifiers);
     }
@@ -244,10 +242,6 @@ public abstract class AbstractJoinOperation extends AbstractDatasetOperation imp
 
     protected ImmutableMap<String, Component> getCommonIdentifiers() {
         return this.commonIdentifiers;
-    }
-
-    protected Set<String> getCommonIdentifierNames() {
-        return this.commonIdentifierNames;
     }
 
     /**

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindings.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindings.java
@@ -1,0 +1,71 @@
+package no.ssb.vtl.script.operations.join;
+
+/*-
+ * ========================LICENSE_START=================================
+ * Java VTL
+ * %%
+ * Copyright (C) 2016 - 2017 Hadrien Kohl
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.google.common.collect.Lists;
+import no.ssb.vtl.model.Component;
+import no.ssb.vtl.model.Dataset;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A bindings that transforms common identifier components across datasets as {@link no.ssb.vtl.model.VTLTyped}.
+ */
+public class CommonIdentifierBindings extends ComponentBindings {
+
+    public CommonIdentifierBindings(Map<String, Dataset> namedDatasets) {
+        List<ComponentBindings> bindingsList = Lists.newArrayList();
+        for (String datasetName : namedDatasets.keySet()) {
+            ComponentBindings componentBindings = new ComponentBindings(namedDatasets.get(datasetName));
+            bindingsList.add(componentBindings);
+            this.put(datasetName, componentBindings);
+        }
+        Set<String> commonIdentifiers = null;
+        for (ComponentBindings componentBindings : bindingsList) {
+            final Set<String> identifiers = componentBindings.entrySet().stream()
+                    .filter(entry -> ((ComponentReference) entry.getValue()).getComponent().isIdentifier())
+                    .map(Entry::getKey).collect(Collectors.toSet());
+            if (commonIdentifiers == null) {
+                commonIdentifiers = identifiers;
+            } else {
+                commonIdentifiers = commonIdentifiers.stream()
+                        .filter(key -> identifiers.contains(key)).collect(Collectors.toSet());
+            }
+        }
+        // Add all components that can be accessed via common identifiers.
+        for (ComponentBindings componentBindings : bindingsList) {
+            for (String identifier : componentBindings.keySet()) {
+                if (commonIdentifiers.contains(identifier) && !this.containsKey(identifier)) {
+                    this.put(identifier, componentBindings.get(identifier));
+                }
+            }
+        }
+    }
+
+    public Map<String, Component> getComponentReferences() {
+        return this.entrySet().stream().filter(e -> e.getValue() instanceof ComponentReference)
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> ((ComponentReference) e.getValue()).getComponent()));
+    }
+
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/ComponentBindings.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/ComponentBindings.java
@@ -71,6 +71,10 @@ public class ComponentBindings extends SimpleBindings {
         return super.put(name, wrapped);
     }
 
+    /**
+     * Creates a Bindings that contains the unique components of this join operation and the
+     * datasets.
+     */
     public ComponentBindings(Map<String, Dataset> namedDatasets) {
         List<ComponentBindings> bindingsList = Lists.newArrayList();
         for (String datasetName : namedDatasets.keySet()) {
@@ -85,7 +89,7 @@ public class ComponentBindings extends SimpleBindings {
         for (ComponentBindings componentBindings : bindingsList) {
             Set<String> identifiers = componentBindings.keySet();
             for (String identifier : identifiers) {
-                if (ambiguous.contains(identifier))
+                    if (ambiguous.contains(identifier))
                     continue;
 
                 if (unique.contains(identifier)) {
@@ -107,7 +111,6 @@ public class ComponentBindings extends SimpleBindings {
         }
     }
 
-
     public ComponentBindings(Dataset dataset) {
         checkNotNull(dataset);
         for (Entry<String, Component> entry : dataset.getDataStructure().entrySet()) {
@@ -116,7 +119,7 @@ public class ComponentBindings extends SimpleBindings {
         }
     }
 
-    private ComponentBindings() {
+    ComponentBindings() {
         // used by copyOf.
     }
 
@@ -155,6 +158,14 @@ public class ComponentBindings extends SimpleBindings {
         @Override
         public Class<? extends VTLObject> getVTLType() {
             return this.type;
+        }
+
+        @Override
+        public String toString() {
+            return "ComponentReference{" +
+                    "component=" + component +
+                    ", type=" + type +
+                    '}';
         }
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
@@ -21,7 +21,6 @@ package no.ssb.vtl.script.operations.join;
  */
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Table;
 import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.Dataset;
@@ -51,14 +50,6 @@ public class InnerJoinOperation extends AbstractJoinOperation {
 
     public InnerJoinOperation(Map<String, Dataset> namedDatasets, Set<Component> identifiers) {
         super(namedDatasets, identifiers);
-        // We need the identifiers in the case of inner join.
-        ComponentBindings joinScope = this.getJoinScope();
-        for (Component component : getCommonIdentifiers()) {
-            joinScope.put(
-                    getDataStructure().getName(component),
-                    component
-            );
-        }
     }
 
     @Override
@@ -80,7 +71,6 @@ public class InnerJoinOperation extends AbstractJoinOperation {
         Closer closer = Closer.create();
         try {
 
-            Table<Component, Dataset, Component> componentMapping = getComponentMapping();
             Stream<DataPoint> original = getOrSortData(
                     left,
                     adjustOrderForStructure(requiredOrder, left.getDataStructure()),

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
@@ -45,7 +45,8 @@ public class OuterJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
 
     public OuterJoinMerger(AbstractJoinOperation joinOperation, Dataset right) {
 
-        Table<String, String, String> mapping = AbstractJoinOperation.getColumnMapping(joinOperation.datasets);
+        Table<String, String, String> mapping = AbstractJoinOperation.getColumnMapping(joinOperation.datasets,
+                joinOperation.getCommonIdentifierNames());
         ImmutableBiMap<Dataset, String> datasetNames = ImmutableBiMap.copyOf(joinOperation.datasets).inverse();
 
         size = mapping.rowKeySet().size();
@@ -58,20 +59,20 @@ public class OuterJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
     @Override
     public DataPoint apply(DataPoint left, DataPoint right) {
 
-        resultView.setDataDoint(DataPoint.create(size));
-        rightView.setDataDoint(right);
+        resultView.setDataPoint(DataPoint.create(size));
+        rightView.setDataPoint(right);
 
         if (left != null) {
-            resultView.setDataDoint(DataPoint.create(left));
+            resultView.setDataPoint(DataPoint.create(left));
         } else {
-            resultView.setDataDoint(DataPoint.create(size));
+            resultView.setDataPoint(DataPoint.create(size));
         }
         if (right != null) {
             for (Map.Entry<String, String> mapping : rightMapping.entrySet()) {
                 resultView.put(mapping.getKey(), rightView.get(mapping.getValue()));
             }
         }
-        return resultView.getDataDoint();
+        return resultView.getDataPoint();
     }
 
     private final class DataPointView implements Map<String, VTLObject> {
@@ -93,11 +94,11 @@ public class OuterJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
             return dp.set(hash.applyAsInt(key), VTLObject.NULL);
         }
 
-        public DataPoint getDataDoint() {
+        public DataPoint getDataPoint() {
             return dp;
         }
 
-        public void setDataDoint(DataPoint dp) {
+        public void setDataPoint(DataPoint dp) {
             this.dp = dp;
         }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
@@ -46,7 +46,7 @@ public class OuterJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
     public OuterJoinMerger(AbstractJoinOperation joinOperation, Dataset right) {
 
         Table<String, String, String> mapping = AbstractJoinOperation.getColumnMapping(joinOperation.datasets,
-                joinOperation.getCommonIdentifierNames());
+                joinOperation.getCommonIdentifiers().keySet());
         ImmutableBiMap<Dataset, String> datasetNames = ImmutableBiMap.copyOf(joinOperation.datasets).inverse();
 
         size = mapping.rowKeySet().size();

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinOperation.java
@@ -76,14 +76,6 @@ public class OuterJoinOperation extends AbstractJoinOperation {
 
     public OuterJoinOperation(Map<String, Dataset> namedDatasets, Set<Component> identifiers) {
         super(namedDatasets, identifiers);
-        // We need the identifiers in the case of inner join.
-        ComponentBindings joinScope = this.getJoinScope();
-        for (Component component : getCommonIdentifiers()) {
-            joinScope.put(
-                    getDataStructure().getName(component),
-                    component
-            );
-        }
     }
 
     @Override

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
@@ -27,7 +27,7 @@ import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.parser.VTLParser;
 import no.ssb.vtl.script.error.ContextualRuntimeException;
 import no.ssb.vtl.script.operations.join.AbstractJoinOperation;
-import no.ssb.vtl.script.operations.join.ComponentBindings;
+import no.ssb.vtl.script.operations.join.CommonIdentifierBindings;
 import no.ssb.vtl.script.operations.join.InnerJoinOperation;
 import no.ssb.vtl.script.operations.join.OuterJoinOperation;
 import no.ssb.vtl.script.visitors.ComponentVisitor;
@@ -68,7 +68,7 @@ public class JoinDefinitionVisitor extends VTLDatasetExpressionVisitor<AbstractJ
     private ImmutableSet<Component> extractIdentifierComponents(List<VTLParser.VariableExpressionContext> identifiers,
                                                                 ImmutableMap<String, Dataset> datasets) {
         ImmutableSet.Builder<Component> builder = ImmutableSet.builder();
-        ComponentVisitor componentVisitor = new ComponentVisitor(new ComponentBindings(datasets));
+        ComponentVisitor componentVisitor = new ComponentVisitor(new CommonIdentifierBindings(datasets));
         for (VTLParser.VariableExpressionContext identifier : identifiers) {
             Component identifierComponent = componentVisitor.visit(identifier);
             builder.add(identifierComponent);

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -1132,11 +1132,7 @@ public class VTLScriptEngineTest {
         Dataset result = (Dataset) bindings.get("result");
         assertThat(result.getDataStructure().getRoles()).containsOnly(
                 entry("id1", Role.IDENTIFIER),
-                //entry("a_id1", Role.IDENTIFIER),
-                //entry("b_id1", Role.IDENTIFIER),
                 entry("id2", Role.IDENTIFIER),
-                //entry("b_id2", Role.IDENTIFIER),
-                //entry("b_id2", Role.IDENTIFIER),
                 entry("a", Role.MEASURE),
                 entry("b", Role.MEASURE)
         );
@@ -1242,9 +1238,7 @@ public class VTLScriptEngineTest {
         Dataset result = (Dataset) bindings.get("result");
         assertThat(result.getDataStructure().getRoles()).containsOnly(
                 entry("id1", Role.IDENTIFIER),
-                //entry("a_id1", Role.IDENTIFIER),
                 entry("a_id2", Role.IDENTIFIER),
-                //entry("b_id1", Role.IDENTIFIER),
                 entry("b_id2", Role.IDENTIFIER),
                 entry("a", Role.MEASURE),
                 entry("b", Role.MEASURE)

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -1132,7 +1132,11 @@ public class VTLScriptEngineTest {
         Dataset result = (Dataset) bindings.get("result");
         assertThat(result.getDataStructure().getRoles()).containsOnly(
                 entry("id1", Role.IDENTIFIER),
+                //entry("a_id1", Role.IDENTIFIER),
+                //entry("b_id1", Role.IDENTIFIER),
                 entry("id2", Role.IDENTIFIER),
+                //entry("b_id2", Role.IDENTIFIER),
+                //entry("b_id2", Role.IDENTIFIER),
                 entry("a", Role.MEASURE),
                 entry("b", Role.MEASURE)
         );
@@ -1190,6 +1194,58 @@ public class VTLScriptEngineTest {
         assertThat(result.getDataStructure().getRoles()).containsOnly(
                 entry("id1", Role.IDENTIFIER),
                 entry("id2", Role.IDENTIFIER),
+                entry("a", Role.MEASURE),
+                entry("b", Role.MEASURE)
+        );
+    }
+
+    @Test
+    public void testInnerJoinOnSingleIdentifier() throws ScriptException {
+        createMultipleIdDatasets();
+        VTLPrintStream out = new VTLPrintStream(System.out);
+        engine.eval("result := [a,b on id1] {\n" +
+                "  rename id1 to commonId,\n" +
+                "  rename a.integerMeasure to a,\n" +
+                "  rename b.integerMeasure to b\n" +
+                "}");
+        out.println(bindings.get("result"));
+        Dataset result = (Dataset) bindings.get("result");
+        assertThat(result.getDataStructure().getRoles()).containsOnly(
+                entry("commonId", Role.IDENTIFIER),
+                entry("a_id2", Role.IDENTIFIER),
+                entry("b_id2", Role.IDENTIFIER),
+                entry("a", Role.MEASURE),
+                entry("b", Role.MEASURE)
+        );
+
+        assertThat(result.getData()).containsExactlyInAnyOrder(
+                DataPoint.create("id1-1", "id2-1", 1, "id2-1", 1),
+                DataPoint.create("id1-1", "id2-1", 1, "id2-3", 1),
+                DataPoint.create("id1-1", "id2-2", 1, "id2-1", 1),
+                DataPoint.create("id1-1", "id2-2", 1, "id2-3", 1),
+                DataPoint.create("id1-2", "id2-1", 2, "id2-1", 2),
+                DataPoint.create("id1-2", "id2-1", 2, "id2-3", 2),
+                DataPoint.create("id1-2", "id2-2", 2, "id2-1", 2),
+                DataPoint.create("id1-2", "id2-2", 2, "id2-3", 2)
+        );
+    }
+
+    @Test
+    public void testOuterJoinOnSingleIdentifier() throws ScriptException {
+        createMultipleIdDatasets();
+        VTLPrintStream out = new VTLPrintStream(System.out);
+        engine.eval("result := [outer a,b on id1] {\n" +
+                "  rename a.integerMeasure to a,\n" +
+                "  rename b.integerMeasure to b\n" +
+                "}");
+        out.println(bindings.get("result"));
+        Dataset result = (Dataset) bindings.get("result");
+        assertThat(result.getDataStructure().getRoles()).containsOnly(
+                entry("id1", Role.IDENTIFIER),
+                //entry("a_id1", Role.IDENTIFIER),
+                entry("a_id2", Role.IDENTIFIER),
+                //entry("b_id1", Role.IDENTIFIER),
+                entry("b_id2", Role.IDENTIFIER),
                 entry("a", Role.MEASURE),
                 entry("b", Role.MEASURE)
         );

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindingsTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindingsTest.java
@@ -9,9 +9,9 @@ package no.ssb.vtl.script.operations.join;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,14 +22,7 @@ package no.ssb.vtl.script.operations.join;
 
 import com.google.common.collect.ImmutableMap;
 import no.ssb.vtl.model.Component;
-import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.StaticDataset;
-import no.ssb.vtl.model.VTLBoolean;
-import no.ssb.vtl.model.VTLDate;
-import no.ssb.vtl.model.VTLFloat;
-import no.ssb.vtl.model.VTLInteger;
-import no.ssb.vtl.model.VTLNumber;
-import no.ssb.vtl.model.VTLString;
 import no.ssb.vtl.model.VTLTyped;
 import org.junit.Test;
 
@@ -37,30 +30,7 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComponentBindingsTest {
-
-    @Test
-    public void testDatasetBindings() {
-
-        Dataset dataset = StaticDataset.create()
-                .addComponent("c1", Component.Role.IDENTIFIER, String.class)
-                .addComponent("c2", Component.Role.IDENTIFIER, Long.class)
-                .addComponent("c3", Component.Role.IDENTIFIER, Double.class)
-                .addComponent("c4", Component.Role.IDENTIFIER, Instant.class)
-                .addComponent("c5", Component.Role.IDENTIFIER, Boolean.class)
-                .addComponent("c6", Component.Role.IDENTIFIER, Number.class)
-                .build();
-
-        ComponentBindings bindings = new ComponentBindings(dataset);
-
-        assertThat(((VTLTyped<?>) bindings.get("c1")).getVTLType()).isEqualTo(VTLString.class);
-        assertThat(((VTLTyped<?>) bindings.get("c2")).getVTLType()).isEqualTo(VTLInteger.class);
-        assertThat(((VTLTyped<?>) bindings.get("c3")).getVTLType()).isEqualTo(VTLFloat.class);
-        assertThat(((VTLTyped<?>) bindings.get("c4")).getVTLType()).isEqualTo(VTLDate.class);
-        assertThat(((VTLTyped<?>) bindings.get("c5")).getVTLType()).isEqualTo(VTLBoolean.class);
-        assertThat(((VTLTyped<?>) bindings.get("c6")).getVTLType()).isEqualTo(VTLNumber.class);
-
-    }
+public class CommonIdentifierBindingsTest {
 
     @Test
     public void testJoinBindingsOneDataset() {
@@ -73,11 +43,12 @@ public class ComponentBindingsTest {
                 .addComponent("a1", Component.Role.MEASURE, Boolean.class)
                 .build();
 
-        ComponentBindings result = new ComponentBindings(ImmutableMap.of(
+        CommonIdentifierBindings result = new CommonIdentifierBindings(ImmutableMap.of(
                 "t1", t1
         ));
 
-        assertThat(result).containsOnlyKeys("id1", "id2", "uni1", "m1", "a1", "t1");
+        assertThat(result).containsOnlyKeys("id1", "id2", "uni1", "t1");
+        assertThat(result.getComponentReferences()).containsOnlyKeys("id1", "id2", "uni1");
 
     }
     @Test
@@ -86,7 +57,7 @@ public class ComponentBindingsTest {
         StaticDataset t1 = StaticDataset.create()
                 .addComponent("id1", Component.Role.IDENTIFIER, String.class)
                 .addComponent("id2", Component.Role.IDENTIFIER, Long.class)
-                .addComponent("uni1", Component.Role.IDENTIFIER, Double.class)
+                .addComponent("id3", Component.Role.IDENTIFIER, Double.class)
                 .addComponent("m1", Component.Role.MEASURE, Instant.class)
                 .addComponent("a1", Component.Role.MEASURE, Boolean.class)
                 .addComponent("t3", Component.Role.MEASURE, Boolean.class)
@@ -95,8 +66,8 @@ public class ComponentBindingsTest {
         StaticDataset t2 = StaticDataset.create()
                 .addComponent("id1", Component.Role.IDENTIFIER, String.class)
                 .addComponent("id2", Component.Role.IDENTIFIER, Long.class)
-                .addComponent("uni2", Component.Role.IDENTIFIER, Double.class)
-                .addComponent("uni5", Component.Role.MEASURE, Instant.class)
+                .addComponent("id3", Component.Role.IDENTIFIER, Double.class)
+                .addComponent("m1", Component.Role.MEASURE, Instant.class)
                 .addComponent("a1", Component.Role.MEASURE, Boolean.class)
                 .addComponent("t1", Component.Role.MEASURE, Boolean.class)
                 .build();
@@ -104,25 +75,21 @@ public class ComponentBindingsTest {
         StaticDataset t3 = StaticDataset.create()
                 .addComponent("id1", Component.Role.IDENTIFIER, String.class)
                 .addComponent("id2", Component.Role.IDENTIFIER, Long.class)
-                .addComponent("uni3", Component.Role.IDENTIFIER, Double.class)
                 .addComponent("m1", Component.Role.MEASURE, Instant.class)
-                .addComponent("uni4", Component.Role.MEASURE, Boolean.class)
                 .addComponent("t2", Component.Role.MEASURE, Boolean.class)
                 .build();
 
-        ComponentBindings result = new ComponentBindings(ImmutableMap.of(
+        CommonIdentifierBindings result = new CommonIdentifierBindings(ImmutableMap.of(
                 "t1", t1,
                 "t2", t2,
                 "t3", t3
         ));
 
-        assertThat(result).containsOnlyKeys("uni4", "uni5", "uni2", "uni3", "uni1", "t1", "t2", "t3");
+        assertThat(result).containsOnlyKeys("id1", "id2", "t1", "t2", "t3");
+        assertThat(result.getComponentReferences()).containsOnlyKeys("id1", "id2");
 
-        assertThat(result.get("uni1")).isInstanceOf(VTLTyped.class);
-        assertThat(result.get("uni2")).isInstanceOf(VTLTyped.class);
-        assertThat(result.get("uni3")).isInstanceOf(VTLTyped.class);
-        assertThat(result.get("uni4")).isInstanceOf(VTLTyped.class);
-        assertThat(result.get("uni5")).isInstanceOf(VTLTyped.class);
+        assertThat(result.get("id1")).isInstanceOf(VTLTyped.class);
+        assertThat(result.get("id2")).isInstanceOf(VTLTyped.class);
 
         assertThat(result.get("t1")).isInstanceOf(ComponentBindings.class);
         assertThat(result.get("t2")).isInstanceOf(ComponentBindings.class);


### PR DESCRIPTION
This PR fixes inner and outer joins as described in the VTL 1.1 specification (1810-1818):

If the **ON** clause is specified then the join is possibly defined on a subset of the common Identifier Components of the Datasets. If the Datasets have common Identifier Components (i.e. with identical names, data type and values domain) that are not specified in the on clause then it is mandatory to refer to those Identifier Components by specifying both the Dataset name and the measure name.

For example, if ds1 and ds2 have some common Identifier Components d1, d2 and d3, the following expression:
`[ ds1,ds2 on d1, d2 ]`
 returns a Dataset with the following Identifier Components:
 `d1, d2, 'ds1.d3', 'ds2.d3'`