### PR TITLE
VTL parsing should only allow common identifiers in the "on" clause for join operations

### DIFF
--- a/java-vtl-parser/src/main/antlr4/no/ssb/vtl/parser/VTL.g4
+++ b/java-vtl-parser/src/main/antlr4/no/ssb/vtl/parser/VTL.g4
@@ -236,7 +236,8 @@ unionExpression : 'union' '(' datasetExpression (',' datasetExpression )* ')' ;
 
 joinExpression : '[' joinDefinition ']' '{' joinBody '}';
 
-joinDefinition : type=( INNER | OUTER | CROSS )? variable (',' variable )* ( 'on' variableExpression (',' variableExpression )* )? ;
+joinDefinition : type=( INNER | OUTER | CROSS )? datasets=joinDefinitionVariables ( 'on' identifiers=joinDefinitionVariables)? ;
+joinDefinitionVariables : variable (',' variable )* ;
 
 joinBody : joinClause (',' joinClause)* ;
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/AbstractJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/AbstractJoinOperation.java
@@ -66,7 +66,7 @@ public abstract class AbstractJoinOperation extends AbstractDatasetOperation imp
     private static final String ERROR_EMPTY_DATASET_LIST = "join operation impossible on empty dataset list";
     private static final String ERROR_INCOMPATIBLE_TYPES = "incompatible identifier types: %s";
     private static final String ERROR_NO_COMMON_IDENTIFIERS = "could not find common identifiers in the datasets %s";
-    private static final String ERROR_NO_COMMON_IDENTIFIERS_WITH_JOIN = "join operation has identifiers %s in the 'on' "
+    private static final String ERROR_NOT_IN_COMMON_IDENTIFIERS = "join operation has identifiers %s in the 'on' "
             + "clause that is not a common identifier in the datasets %s";
     protected final ImmutableMap<String, Dataset> datasets;
     private final ImmutableMap<String, Component> commonIdentifiers;
@@ -92,12 +92,12 @@ public abstract class AbstractJoinOperation extends AbstractDatasetOperation imp
                 .collect(Collectors.toSet()));
 
         // Check for common identifiers
-        if(namedDatasets.size() > 1 && commonIdentifiers.isEmpty() && identifiers.isEmpty()) {
-            throw new IllegalStateException(String.format(ERROR_NO_COMMON_IDENTIFIERS, namedDatasets));
-        }
-        if(namedDatasets.size() > 1 && commonIdentifiers.isEmpty() && !identifiers.isEmpty()) {
-            throw new IllegalStateException(String.format(ERROR_NO_COMMON_IDENTIFIERS_WITH_JOIN, identifiers,
-                    namedDatasets));
+        if(namedDatasets.size() > 1 && commonIdentifiers.isEmpty()) {
+            if (identifiers.isEmpty()) {
+                throw new IllegalStateException(String.format(ERROR_NO_COMMON_IDENTIFIERS, namedDatasets));
+            } else {
+                throw new IllegalStateException(String.format(ERROR_NOT_IN_COMMON_IDENTIFIERS, identifiers, namedDatasets));
+            }
         }
 
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindings.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindings.java
@@ -36,10 +36,9 @@ public class CommonIdentifierBindings extends ComponentBindings {
 
     public CommonIdentifierBindings(Map<String, Dataset> namedDatasets) {
         List<ComponentBindings> bindingsList = Lists.newArrayList();
-        for (String datasetName : namedDatasets.keySet()) {
-            ComponentBindings componentBindings = new ComponentBindings(namedDatasets.get(datasetName));
+        for (Map.Entry<String, Dataset> entry : namedDatasets.entrySet()) {
+            ComponentBindings componentBindings = new ComponentBindings(entry.getValue());
             bindingsList.add(componentBindings);
-            this.put(datasetName, componentBindings);
         }
         Set<String> commonIdentifiers = null;
         for (ComponentBindings componentBindings : bindingsList) {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CrossJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/CrossJoinOperation.java
@@ -52,10 +52,10 @@ import java.util.Set;
 public abstract class CrossJoinOperation extends OuterJoinOperation {
 
     CrossJoinOperation(Map<String, Dataset> namedDatasets) {
-        super(namedDatasets, Collections.emptySet());
+        super(namedDatasets, Collections.emptyMap());
     }
 
-    public CrossJoinOperation(Map<String, Dataset> namedDatasets, Set<Component> identifiers) {
+    public CrossJoinOperation(Map<String, Dataset> namedDatasets, Map<String, Component> identifiers) {
         super(namedDatasets, identifiers);
     }
 }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/InnerJoinOperation.java
@@ -45,10 +45,10 @@ public class InnerJoinOperation extends AbstractJoinOperation {
 
 
     public InnerJoinOperation(Map<String, Dataset> namedDatasets) {
-        this(namedDatasets, Collections.emptySet());
+        this(namedDatasets, Collections.emptyMap());
     }
 
-    public InnerJoinOperation(Map<String, Dataset> namedDatasets, Set<Component> identifiers) {
+    public InnerJoinOperation(Map<String, Dataset> namedDatasets, Map<String, Component> identifiers) {
         super(namedDatasets, identifiers);
     }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinOperation.java
@@ -71,10 +71,10 @@ import java.util.stream.StreamSupport;
 public class OuterJoinOperation extends AbstractJoinOperation {
 
     public OuterJoinOperation(Map<String, Dataset> namedDatasets) {
-        this(namedDatasets, Collections.emptySet());
+        this(namedDatasets, Collections.emptyMap());
     }
 
-    public OuterJoinOperation(Map<String, Dataset> namedDatasets, Set<Component> identifiers) {
+    public OuterJoinOperation(Map<String, Dataset> namedDatasets, Map<String, Component> identifiers) {
         super(namedDatasets, identifiers);
     }
 

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
@@ -21,7 +21,6 @@ package no.ssb.vtl.script.visitors.join;
  */
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.parser.VTLParser;
@@ -65,11 +64,11 @@ public class JoinDefinitionVisitor extends VTLDatasetExpressionVisitor<AbstractJ
         return builder.build();
     }
 
-    private ImmutableMap<String, Component> extractIdentifierComponents(List<VTLParser.VariableExpressionContext> identifiers,
+    private ImmutableMap<String, Component> extractIdentifierComponents(List<VTLParser.VariableContext> identifiers,
                                                                 ImmutableMap<String, Dataset> datasets) {
         ImmutableMap.Builder<String, Component> builder = ImmutableMap.builder();
         ComponentVisitor componentVisitor = new ComponentVisitor(new CommonIdentifierBindings(datasets));
-        for (VTLParser.VariableExpressionContext identifier : identifiers) {
+        for (VTLParser.VariableContext identifier : identifiers) {
             Component identifierComponent = componentVisitor.visit(identifier);
             builder.put(identifier.getText(), identifierComponent);
         }
@@ -80,9 +79,11 @@ public class JoinDefinitionVisitor extends VTLDatasetExpressionVisitor<AbstractJ
     public AbstractJoinOperation visitJoinDefinition(VTLParser.JoinDefinitionContext ctx) {
 
         // Create a component bindings to be able to resolve components.
-        ImmutableMap<String, Dataset> datasets = extractDatasets(ctx.variable());
+        ImmutableMap<String, Dataset> datasets = extractDatasets(ctx.datasets.variable());
 
-        ImmutableMap<String, Component> identifiers = extractIdentifierComponents(ctx.variableExpression(), datasets);
+        ImmutableMap<String, Component> identifiers = ctx.identifiers == null
+                ? ImmutableMap.of()
+                : extractIdentifierComponents(ctx.identifiers.variable(), datasets);
 
         Integer joinType = Optional.ofNullable(ctx.type).map(Token::getType).orElse(VTLParser.INNER);
         switch (joinType) {

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/visitors/join/JoinDefinitionVisitor.java
@@ -65,13 +65,13 @@ public class JoinDefinitionVisitor extends VTLDatasetExpressionVisitor<AbstractJ
         return builder.build();
     }
 
-    private ImmutableSet<Component> extractIdentifierComponents(List<VTLParser.VariableExpressionContext> identifiers,
+    private ImmutableMap<String, Component> extractIdentifierComponents(List<VTLParser.VariableExpressionContext> identifiers,
                                                                 ImmutableMap<String, Dataset> datasets) {
-        ImmutableSet.Builder<Component> builder = ImmutableSet.builder();
+        ImmutableMap.Builder<String, Component> builder = ImmutableMap.builder();
         ComponentVisitor componentVisitor = new ComponentVisitor(new CommonIdentifierBindings(datasets));
         for (VTLParser.VariableExpressionContext identifier : identifiers) {
             Component identifierComponent = componentVisitor.visit(identifier);
-            builder.add(identifierComponent);
+            builder.put(identifier.getText(), identifierComponent);
         }
         return builder.build();
     }
@@ -82,7 +82,7 @@ public class JoinDefinitionVisitor extends VTLDatasetExpressionVisitor<AbstractJ
         // Create a component bindings to be able to resolve components.
         ImmutableMap<String, Dataset> datasets = extractDatasets(ctx.variable());
 
-        ImmutableSet<Component> identifiers = extractIdentifierComponents(ctx.variableExpression(), datasets);
+        ImmutableMap<String, Component> identifiers = extractIdentifierComponents(ctx.variableExpression(), datasets);
 
         Integer joinType = Optional.ofNullable(ctx.type).map(Token::getType).orElse(VTLParser.INNER);
         switch (joinType) {

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/foreach/ForeachOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/foreach/ForeachOperationTest.java
@@ -87,9 +87,9 @@ public class ForeachOperationTest {
                     "t1", t1.get(),
                     "t2", t2.get()
             );
-            ImmutableSet<Component> identifier = ImmutableSet.of(
-                    t1.get().getDataStructure().get("year"),
-                    t1.get().getDataStructure().get("id")
+            ImmutableMap<String, Component> identifier = ImmutableMap.of(
+                    "t1.year", t1.get().getDataStructure().get("year"),
+                    "t1.id", t1.get().getDataStructure().get("id")
             );
             return VTLDataset.of(new InnerJoinOperation(namedDataset, identifier));
         });

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindingsTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/CommonIdentifierBindingsTest.java
@@ -47,7 +47,7 @@ public class CommonIdentifierBindingsTest {
                 "t1", t1
         ));
 
-        assertThat(result).containsOnlyKeys("id1", "id2", "uni1", "t1");
+        assertThat(result).containsOnlyKeys("id1", "id2", "uni1");
         assertThat(result.getComponentReferences()).containsOnlyKeys("id1", "id2", "uni1");
 
     }
@@ -85,14 +85,10 @@ public class CommonIdentifierBindingsTest {
                 "t3", t3
         ));
 
-        assertThat(result).containsOnlyKeys("id1", "id2", "t1", "t2", "t3");
+        assertThat(result).containsOnlyKeys("id1", "id2");
         assertThat(result.getComponentReferences()).containsOnlyKeys("id1", "id2");
 
         assertThat(result.get("id1")).isInstanceOf(VTLTyped.class);
         assertThat(result.get("id2")).isInstanceOf(VTLTyped.class);
-
-        assertThat(result.get("t1")).isInstanceOf(ComponentBindings.class);
-        assertThat(result.get("t2")).isInstanceOf(ComponentBindings.class);
-        assertThat(result.get("t3")).isInstanceOf(ComponentBindings.class);
     }
 }

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/join/InnerJoinOperationTest.java
@@ -125,7 +125,7 @@ public class InnerJoinOperationTest extends RandomizedTest {
         InnerJoinOperation joinOperation = new InnerJoinOperation(
                 ImmutableMap.of(
                         "ds1", ds1, "ds2", ds2
-                ), Collections.emptySet()
+                ), Collections.emptyMap()
         );
 
         // This order is not possible.


### PR DESCRIPTION
CommonIdentifierBindings now doesn't have bindings to the datasets, only the identifier keys. This means that dataset prefix in the 'on' clause in join operations is no longer allowed. This makes a more strict VTL parsing, so one can only use common identifiers, and not just any identifier.