### PR TITLE
Handle datasets with unequal attribute variables in union operation

### DIFF
--- a/java-vtl-script/pom.xml
+++ b/java-vtl-script/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>LATEST</version>
+            <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/java-vtl-script/pom.xml
+++ b/java-vtl-script/pom.xml
@@ -57,12 +57,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.carrotsearch.randomizedtesting</groupId>
-            <artifactId>randomizedtesting-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>LATEST</version>
@@ -72,6 +66,13 @@
         <dependency>
             <groupId>org.brotli</groupId>
             <artifactId>dec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMap.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMap.java
@@ -61,6 +61,14 @@ public class DataPointMap {
     /**
      * Update the underlying Datapoint value.
      */
+    public DataPointMap withDataPoint(DataPoint dataPoint) {
+        this.dataPoint = dataPoint;
+        return this;
+    }
+
+    /**
+     * Update the underlying Datapoint value.
+     */
     public void setDataPoint(DataPoint dataPoint) {
         this.dataPoint = dataPoint;
     }

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMapComparator.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMapComparator.java
@@ -31,21 +31,21 @@ public class DataPointMapComparator implements Comparator<DataPointMap> {
 
     private final VtlOrdering vtlOrdering;
 
+    @SuppressWarnings("unchecked")
+    private final static Comparator<VTLObject> vtlObjectComparator = Comparator.comparing((VTLObject object) ->
+            (Comparable) object.get(), Comparator.nullsLast(Comparator.naturalOrder()));
+
     public DataPointMapComparator(VtlOrdering vtlOrdering) {
         this.vtlOrdering = vtlOrdering;
     }
 
     @Override
     public int compare(DataPointMap o1, DataPointMap o2) {
-        @SuppressWarnings("unchecked")
-        Comparator<VTLObject> vtlObjectComparator = Comparator.comparing((VTLObject object) ->
-                        (Comparable) object.get(), Comparator.nullsLast(Comparator.naturalOrder()));
         int result = 0;
         for (String column : vtlOrdering.columns()) {
-            Ordering.Direction direction = vtlOrdering.getDirection(column);
             result = vtlObjectComparator.compare(o1.get(column), o2.get(column));
             if (result != 0) {
-                return direction == Ordering.Direction.ASC ? result : -result;
+                return vtlOrdering.getDirection(column) == Ordering.Direction.ASC ? result : -result;
             }
         }
         return result;

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMapComparator.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/DataPointMapComparator.java
@@ -1,0 +1,53 @@
+package no.ssb.vtl.script.operations;
+
+/*
+ * -
+ *   ========================LICENSE_START=================================
+ *   Java VTL
+ *   %%
+ *   Copyright (C) 2019 Arild Johan Takvam-Borge
+ *   %%
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *   =========================LICENSE_END==================================
+ */
+
+import no.ssb.vtl.model.Ordering;
+import no.ssb.vtl.model.VTLObject;
+import no.ssb.vtl.model.VtlOrdering;
+
+import java.util.Comparator;
+
+public class DataPointMapComparator implements Comparator<DataPointMap> {
+
+    private final VtlOrdering vtlOrdering;
+
+    public DataPointMapComparator(VtlOrdering vtlOrdering) {
+        this.vtlOrdering = vtlOrdering;
+    }
+
+    @Override
+    public int compare(DataPointMap o1, DataPointMap o2) {
+        @SuppressWarnings("unchecked")
+        Comparator<VTLObject> vtlObjectComparator = Comparator.comparing((VTLObject object) ->
+                        (Comparable) object.get(), Comparator.nullsLast(Comparator.naturalOrder()));
+        int result = 0;
+        for (String column : vtlOrdering.columns()) {
+            Ordering.Direction direction = vtlOrdering.getDirection(column);
+            result = vtlObjectComparator.compare(o1.get(column), o2.get(column));
+            if (result != 0) {
+                return direction == Ordering.Direction.ASC ? result : -result;
+            }
+        }
+        return result;
+    }
+}

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/foreach/DataPointMap.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/foreach/DataPointMap.java
@@ -33,6 +33,10 @@ import no.ssb.vtl.model.VTLObject;
 import java.util.Map;
 import java.util.function.Supplier;
 
+/**
+ * Use {@link no.ssb.vtl.script.operations.DataPointMap}
+ */
+@Deprecated
 public final class DataPointMap {
 
     private final ImmutableList<String> names;

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/join/OuterJoinMerger.java
@@ -81,6 +81,11 @@ public class OuterJoinMerger implements BiFunction<DataPoint, DataPoint, DataPoi
         private DataPoint dp = DataPoint.create(0);
 
 
+        /**
+         * Use {@link no.ssb.vtl.script.operations.DataPointMap} (maybe merge)
+         *
+         */
+        @Deprecated
         public DataPointView(DataStructure structure) {
             ImmutableList<String> list = ImmutableSet.copyOf(structure.keySet()).asList();
             this.hash = list::indexOf;

--- a/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/union/UnionOperation.java
+++ b/java-vtl-script/src/main/java/no/ssb/vtl/script/operations/union/UnionOperation.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Sets;
 import no.ssb.vtl.model.Component;
 import no.ssb.vtl.model.DataPoint;
 import no.ssb.vtl.model.DataStructure;
-import no.ssb.vtl.model.DatapointNormalizer;
 import no.ssb.vtl.model.Dataset;
 import no.ssb.vtl.model.Filtering;
 import no.ssb.vtl.model.FilteringSpecification;
@@ -38,18 +37,26 @@ import no.ssb.vtl.model.OrderingSpecification;
 import no.ssb.vtl.model.VtlFiltering;
 import no.ssb.vtl.model.VtlOrdering;
 import no.ssb.vtl.script.operations.AbstractDatasetOperation;
+import no.ssb.vtl.script.operations.DataPointMap;
+import no.ssb.vtl.script.operations.DataPointMapComparator;
 import no.ssb.vtl.script.operations.VtlStream;
+import no.ssb.vtl.script.operations.join.DataPointCapacityExpander;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Arrays.asList;
+import static no.ssb.vtl.model.DataStructure.Entry;
+import static no.ssb.vtl.model.DataStructure.builder;
 
 /**
  * Union operator
@@ -71,7 +78,29 @@ public class UnionOperation extends AbstractDatasetOperation {
 
     @Override
     protected DataStructure computeDataStructure() {
-        return getChildren().get(0).getDataStructure();
+        if (getChildren().size() == 1) {
+            return getChildren().get(0).getDataStructure();
+        }
+
+        // Get base structure, that is, structure from first parameter, without attributes
+        List<Entry<String, Component>> baseStructure
+                = new ArrayList<>(getChildren().get(0).getDataStructure().entrySet())
+                .stream().filter(entry -> entry.getValue().getRole() != Component.Role.ATTRIBUTE)
+                .collect(Collectors.toList());
+
+        // Add attributes, sorted by name
+        List<Entry<String, Component>> allAttributes = new ArrayList<>();
+        for(Dataset dataset : getChildren()) {
+            List<Entry<String, Component>> childAttributes = dataset.getDataStructure().entrySet()
+                    .stream().filter(entry -> entry.getValue().getRole() == Component.Role.ATTRIBUTE)
+                    .filter(entry -> allAttributes.stream()
+                            .noneMatch(attributeEntry -> attributeEntry.getKey().equals(entry.getKey())))
+                    .collect(Collectors.toList());
+            allAttributes.addAll(childAttributes);
+        }
+        allAttributes.sort(Comparator.comparing(Entry::getKey));
+        baseStructure.addAll(allAttributes);
+        return builder().putAll(baseStructure).build();
     }
 
     @Override
@@ -147,25 +176,67 @@ public class UnionOperation extends AbstractDatasetOperation {
         VtlOrdering unionOrder = (VtlOrdering) computeRequiredOrdering(ordering);
 
         DataStructure structure = getDataStructure();
-        ImmutableList.Builder<Stream<DataPoint>> streams = ImmutableList.builder();
+        ImmutableList.Builder<Stream<DataPointMap>> streams = ImmutableList.builder();
         ImmutableList.Builder<Stream<DataPoint>> originals = ImmutableList.builder();
         for (AbstractDatasetOperation child : getChildren()) {
 
-            VtlOrdering unionOrdering = new VtlOrdering(unionOrder, child.getDataStructure());
-            VtlFiltering unionFilter = VtlFiltering.using(child).with(childFiltering);
+            DataStructure childStructure = getNormalizedChildStructure(child.getDataStructure(), structure);
+            VtlOrdering unionOrdering = new VtlOrdering(unionOrder, childStructure);
+            VtlFiltering unionFilter = VtlFiltering.using(child).transpose(childFiltering);
 
-            Stream<DataPoint> stream = child.computeData(unionOrdering, unionFilter, components);
+            Stream<DataPoint> stream = child.computeData(unionOrdering, unionFilter, components)
+                    .peek(
+                            new DataPointCapacityExpander(structure.size()));
+
             originals.add(stream);
-            streams.add(stream.map(new DatapointNormalizer(child.getDataStructure(), structure)));
+            Stream<DataPoint> testStream = StreamSupport.stream(stream.spliterator(), false);
+
+            DataPointMap map = new DataPointMap(childStructure);
+            Stream<DataPointMap> dataPointMapStream = testStream.map(map::withDataPoint);
+            streams.add(dataPointMapStream);
         }
 
         VtlOrdering unionOrdering = new VtlOrdering(unionOrder, structure);
+        Comparator<DataPointMap> comparing = new DataPointMapComparator(unionOrdering);
+
+        ImmutableList<Stream<DataPointMap>> build = streams.build();
+
+        DataPointMap resultMap = new DataPointMap(structure);
         Stream<DataPoint> result = StreamUtils.interleave(
-                createSelector(unionOrdering), streams.build()
-        ).map(new DuplicateChecker(unionOrdering, structure));
+                createSelector(comparing), build)
+                .map(source -> {
+                    resultMap.setDataPoint(DataPoint.create(structure.size()));
+                    structure.keySet().forEach(col -> resultMap.set(col, source.get(col)));
+                    return resultMap.getDataPoint();
+                }).map(new DuplicateChecker(unionOrdering, structure));
 
         return new VtlStream(
                 this, result, originals.build(), ordering, filtering, unionOrdering, childFiltering);
+    }
+
+    /**
+     * Concatenates the child's structure with the base structure, to add attributes not present in child
+     *
+     * @param childStructure the child's structure
+     * @param baseStructure the base structure for the expression, containing the sum of all attributes from all
+     *                      parameters
+     * @return the concatenated structure
+     */
+    private DataStructure getNormalizedChildStructure(DataStructure childStructure, DataStructure baseStructure) {
+        if (childStructure.getRoles().size() == baseStructure.getRoles().size()
+                && childStructure.getRoles().keySet().equals(baseStructure.getRoles().keySet())) {
+            return childStructure;
+        }
+
+        List<Entry<String, Component>> childStructureList = new ArrayList<>(childStructure.entrySet());
+
+        // append missing attributes from baseStructure
+        childStructureList.addAll(baseStructure.entrySet().stream()
+                .filter(entry -> childStructureList.stream()
+                        .map(Entry::getKey).noneMatch(key -> key.equals(entry.getKey())))
+                .collect(Collectors.toList()));
+
+        return DataStructure.builder().putAll(childStructureList).build();
     }
 
     private <T> Selector<T> createSelector(Comparator<T> comparator) {

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static no.ssb.vtl.model.Component.Role;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1149,7 +1150,8 @@ public class VTLScriptEngineTest {
                         "ds4 := [ds3]{" +
                         "filter at1 = \"attr1-2\"" +
                         " or m1 = 10" +
-                        "}");
+                        "}" +
+                        "");
 
         assertThat(bindings).containsKey("ds3");
         assertThat(bindings).containsKey("ds4");
@@ -1158,7 +1160,7 @@ public class VTLScriptEngineTest {
 
         Dataset ds3 = (Dataset) bindings.get("ds3");
         assertThat(ds3.getDataStructure())
-                .describedAs("data structure of d4")
+                .describedAs("data structure of d3")
                 .containsOnlyKeys(
                         "id1",
                         "m1",
@@ -1175,8 +1177,8 @@ public class VTLScriptEngineTest {
                         "m2",
                         "at1"
                 );
-
-        assertThat(ds3.getData())
+        Stream<DataPoint> data = ds3.getData();
+        assertThat(data)
                 .containsExactlyInAnyOrder(
                         DataPoint.create("1", 10L, 20D, null),
                         DataPoint.create("2", 100L, 200D, null),

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/VTLScriptEngineTest.java
@@ -1121,6 +1121,199 @@ public class VTLScriptEngineTest {
     }
 
     @Test
+    public void testUnionWithFilter() throws Exception {
+        Dataset ds1 = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.MEASURE, Long.class)
+                .addComponent("m2", Role.MEASURE, Double.class)
+
+                .addPoints("1", 10L, 20D)
+                .addPoints("2", 100L, 200D)
+                .build();
+
+        Dataset ds2 = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.MEASURE, Long.class)
+                .addComponent("m2", Role.MEASURE, Double.class)
+                .addComponent("at1", Role.ATTRIBUTE, String.class)
+
+                .addPoints("3", 30L, 40D, "attr1-1")
+                .addPoints("4", 300L, 400D, "attr1-2")
+                .build();
+
+        bindings.put("ds1", ds1);
+        bindings.put("ds2", ds2);
+
+        engine.eval(
+                "ds3 := union(ds1, ds2)" +
+                        "ds4 := [ds3]{" +
+                        "filter at1 = \"attr1-2\"" +
+                        " or m1 = 10" +
+                        "}");
+
+        assertThat(bindings).containsKey("ds3");
+        assertThat(bindings).containsKey("ds4");
+        assertThat(bindings.get("ds3")).isInstanceOf(Dataset.class);
+        assertThat(bindings.get("ds4")).isInstanceOf(Dataset.class);
+
+        Dataset ds3 = (Dataset) bindings.get("ds3");
+        assertThat(ds3.getDataStructure())
+                .describedAs("data structure of d4")
+                .containsOnlyKeys(
+                        "id1",
+                        "m1",
+                        "m2",
+                        "at1"
+                );
+
+        Dataset ds4 = (Dataset) bindings.get("ds4");
+        assertThat(ds4.getDataStructure())
+                .describedAs("data structure of d4")
+                .containsOnlyKeys(
+                        "id1",
+                        "m1",
+                        "m2",
+                        "at1"
+                );
+
+        assertThat(ds3.getData())
+                .containsExactlyInAnyOrder(
+                        DataPoint.create("1", 10L, 20D, null),
+                        DataPoint.create("2", 100L, 200D, null),
+                        DataPoint.create("3", 30L, 40D, "attr1-1"),
+                        DataPoint.create("4", 300L, 400D, "attr1-2")
+                );
+
+        assertThat(ds4.getData())
+                .containsExactlyInAnyOrder(
+                        DataPoint.create("1", 10L, 20D, null),
+                        DataPoint.create("4", 300L, 400D, "attr1-2")
+                );
+    }
+
+    @Test
+    public void testMultipleUnions() throws Exception {
+
+        Dataset ds1 = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.MEASURE, Long.class)
+                .addComponent("m2", Role.MEASURE, Double.class)
+
+                .addPoints("1", 10L, 20D)
+                .addPoints("2", 100L, 200D)
+                .build();
+
+        Dataset ds2 = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.MEASURE, Long.class)
+                .addComponent("m2", Role.MEASURE, Double.class)
+                .addComponent("at1", Role.ATTRIBUTE, String.class)
+
+                .addPoints("3", 30L, 40D, "attr1-1")
+                .addPoints("4", 300L, 400D, "attr1-2")
+                .build();
+
+        Dataset ds3 = StaticDataset.create()
+                .addComponent("id1", Role.IDENTIFIER, String.class)
+                .addComponent("m1", Role.MEASURE, Long.class)
+                .addComponent("m2", Role.MEASURE, Double.class)
+                .addComponent("at2", Role.ATTRIBUTE, String.class)
+
+                .addPoints("5", 50L, 60D, "attr2-1")
+                .addPoints("6", 500L, 600D, "attr2-2")
+                .build();
+
+
+        bindings.put("ds1", ds1);
+        bindings.put("ds2", ds2);
+        bindings.put("ds3", ds3);
+
+        engine.eval(
+                "ds4 := union(ds1, ds2, ds3)" +
+                "ds5 := union(ds2, ds3, ds1)" +
+                "ds6 := union(ds3, ds1, ds2)");
+
+        assertThat(bindings).containsKey("ds4");
+        assertThat(bindings).containsKey("ds5");
+        assertThat(bindings).containsKey("ds6");
+        assertThat(bindings.get("ds4")).isInstanceOf(Dataset.class);
+        assertThat(bindings.get("ds5")).isInstanceOf(Dataset.class);
+        assertThat(bindings.get("ds6")).isInstanceOf(Dataset.class);
+
+        Dataset ds4 = (Dataset) bindings.get("ds4");
+        assertThat(ds4.getDataStructure())
+                .describedAs("data structure of d4")
+                .containsOnlyKeys(
+                        "id1",
+                        "m1",
+                        "m2",
+                        "at1",
+                        "at2"
+                );
+
+        Dataset ds5 = (Dataset) bindings.get("ds5");
+        assertThat(ds5.getDataStructure())
+                .describedAs("data structure of ds5")
+                .containsOnlyKeys(
+                        "id1",
+                        "m1",
+                        "m2",
+                        "at1",
+                        "at2"
+                );
+
+        Dataset ds6 = (Dataset) bindings.get("ds6");
+        assertThat(ds6.getDataStructure())
+                .describedAs("data structure of ds6")
+                .containsOnlyKeys(
+                        "id1",
+                        "m1",
+                        "m2",
+                        "at1",
+                        "at2"
+                );
+
+        assertThat(ds4.getData())
+                .containsExactlyInAnyOrder(
+                        DataPoint.create("1", 10L, 20D, null, null),
+                        DataPoint.create("2", 100L, 200D, null, null),
+                        DataPoint.create("3", 30L, 40D, "attr1-1", null),
+                        DataPoint.create("4", 300L, 400D, "attr1-2", null),
+                        DataPoint.create("5", 50L, 60D, null, "attr2-1"),
+                        DataPoint.create("6", 500L, 600D, null, "attr2-2")
+                );
+        assertThat(ds5.getData())
+                .containsExactlyInAnyOrder(
+                        DataPoint.create("1", 10L, 20D, null, null),
+                        DataPoint.create("2", 100L, 200D, null, null),
+                        DataPoint.create("3", 30L, 40D, "attr1-1", null),
+                        DataPoint.create("4", 300L, 400D, "attr1-2", null),
+                        DataPoint.create("5", 50L, 60D, null, "attr2-1"),
+                        DataPoint.create("6", 500L, 600D, null, "attr2-2")
+                );
+        assertThat(ds6.getData())
+                .containsExactlyInAnyOrder(
+                        DataPoint.create("1", 10L, 20D, null, null),
+                        DataPoint.create("2", 100L, 200D, null, null),
+                        DataPoint.create("3", 30L, 40D, "attr1-1", null),
+                        DataPoint.create("4", 300L, 400D, "attr1-2", null),
+                        DataPoint.create("5", 50L, 60D, null, "attr2-1"),
+                        DataPoint.create("6", 500L, 600D, null, "attr2-2")
+                );
+        assertThat(ds6.getData())
+                .flatExtracting(input -> input)
+                .extracting(VTLObject::get)
+                .containsExactly(
+                        "1", 10L, 20D, null, null,
+                        "2", 100L, 200D, null, null,
+                        "3", 30L, 40D, "attr1-1", null,
+                        "4", 300L, 400D, "attr1-2", null,
+                        "5", 50L, 60D, null, "attr2-1",
+                        "6", 500L, 600D, null, "attr2-2"
+                );
+    }
+
+    @Test
     public void testOuterJoinWithMultipleIds() throws ScriptException {
         createMultipleIdDatasets();
         VTLPrintStream out = new VTLPrintStream(System.out);

--- a/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/union/UnionOperationTest.java
+++ b/java-vtl-script/src/test/java/no/ssb/vtl/script/operations/union/UnionOperationTest.java
@@ -40,7 +40,9 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +51,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static no.ssb.vtl.model.Component.Role;
+import static no.ssb.vtl.model.DataStructure.Entry;
+import static no.ssb.vtl.model.DataStructure.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -56,21 +60,231 @@ import static org.mockito.Mockito.when;
 
 public class UnionOperationTest extends RandomizedTest {
 
-    private DataStructure dataStructure;
+    private DataStructure dataStructure1;
+    private DataPoint[] resultWithDataStructure1First;
+    private DataStructure dataStructure2;
+    private DataPoint[] resultWithDataStructure2First;
+    private DataStructure dataStructure3;
+    private DataPoint[] resultWithDataStructure3First;
+
 
 
     @Before
     public void setUp() {
-        dataStructure = DataStructure.of(
+        dataStructure1 = DataStructure.of(
                 "TIME", Role.IDENTIFIER, String.class,
                 "GEO", Role.IDENTIFIER, String.class,
                 "POP", Role.MEASURE, Long.class
         );
+
+        dataStructure2 = DataStructure.of(
+                "GEO", Role.IDENTIFIER, String.class,
+                "TIME", Role.IDENTIFIER, String.class,
+                "POP", Role.MEASURE, Long.class,
+                "A1", Role.ATTRIBUTE, Long.class
+        );
+
+        dataStructure3 = DataStructure.of(
+                "POP", Role.MEASURE, Long.class,
+                "TIME", Role.IDENTIFIER, String.class,
+                "A2", Role.ATTRIBUTE, Long.class,
+                "GEO", Role.IDENTIFIER, String.class
+        );
+
+        resultWithDataStructure1First = new DataPoint[]{
+                dataPoint("2012", "Belgium", 5L, null, null),
+                dataPoint("2012", "Finland", 9L, null, null),
+                dataPoint("2012", "France", 3L, null, null),
+                dataPoint("2012", "Greece", 2L, null, null),
+                dataPoint("2012", "Iceland", 1L, 3L, null),
+                dataPoint("2012", "Malta", 7L, null, null),
+                dataPoint("2012", "Spain", 5L, 2L, null),
+                dataPoint("2012", "Switzerland", 12L, null, null),
+                dataPoint("2012", null, 23L, 1L, null),
+                dataPoint("2013", "Iceland", 1L, null, 3L),
+                dataPoint("2013", "Netherlands", 23L, null, 1L),
+                dataPoint(null, "Spain", 5L, null, 2L),
+        };
+
+        resultWithDataStructure2First = new DataPoint[]{
+                dataPoint("Belgium", "2012", 5L, null, null),
+                dataPoint("Finland", "2012", 9L, null, null),
+                dataPoint("France", "2012", 3L, null, null),
+                dataPoint("Greece", "2012", 2L, null, null),
+                dataPoint("Iceland", "2012", 1L, 3L, null),
+                dataPoint("Iceland", "2013", 1L, null, 3L),
+                dataPoint("Malta", "2012", 7L, null, null),
+                dataPoint("Netherlands", "2013", 23L, null, 1L),
+                dataPoint("Spain", "2012", 5L, 2L, null),
+                dataPoint("Spain", null, 5L, null, 2L),
+                dataPoint("Switzerland", "2012", 12L, null, null),
+                dataPoint(null, "2012", 23L, 1L, null),
+        };
+
+        resultWithDataStructure3First = new DataPoint[]{
+                dataPoint(5L, "2012", "Belgium", null, null),
+                dataPoint(9L, "2012", "Finland", null, null),
+                dataPoint(3L, "2012", "France", null, null),
+                dataPoint(2L, "2012", "Greece", null, null),
+                dataPoint(1L, "2012", "Iceland", 3L, null),
+                dataPoint(7L, "2012", "Malta", null, null),
+                dataPoint(5L, "2012", "Spain", 2L, null),
+                dataPoint(12L, "2012", "Switzerland", null, null),
+                dataPoint(23L, "2012", null, 1L, null),
+                dataPoint(1L, "2013", "Iceland", null, 3L),
+                dataPoint(23L, "2013", "Netherlands", null, 1L),
+                dataPoint(5L, null, "Spain", null, 2L),
+        };
+
     }
 
+    private TestableDataset createDataset1() {
+        return new TestableDataset(Lists.newArrayList(
+                dataPoint("2012", "Belgium", 5L),
+                dataPoint("2012", "Greece", 2L),
+                dataPoint("2012", "France", 3L),
+                dataPoint("2012", "Malta", 7L),
+                dataPoint("2012", "Finland", 9L),
+                dataPoint("2012", "Switzerland", 12L)
+        ), dataStructure1);
+    }
+
+    private TestableDataset createDataset2() {
+        return new TestableDataset(Lists.newArrayList(
+                dataPoint(null, "2012", 23L, 1L),
+                dataPoint("Spain", "2012", 5L, 2L),
+                dataPoint("Iceland", "2012", 1L, 3L)
+        ), dataStructure2);
+    }
+
+    private TestableDataset createDataset3() {
+        return new TestableDataset(Lists.newArrayList(
+                dataPoint(23L, "2013", 1L, "Netherlands"),
+                dataPoint(5L, null, 2L, "Spain"),
+                dataPoint(1L, "2013", 3L, "Iceland")
+        ), dataStructure3);
+    }
 
     @Test
-    public void testSameIdentifierAndMeasures() throws Exception {
+    public void testWithAttributesInBoth() {
+        SoftAssertions softly = new SoftAssertions();
+
+        try {
+            Dataset dataset1 = new TestableDataset(Lists.newArrayList(
+                    dataPoint("2012", "Belgium", 5L, 1L),
+                    dataPoint("2012", "Greece", 2L, 2L),
+                    dataPoint("2012", "France", 3L, 3L),
+                    dataPoint("2012", "Malta", 7L, 4L),
+                    dataPoint("2012", "Finland", 9L, 5L),
+                    dataPoint("2012", "Switzerland", 12L, 6L)
+            ), dataStructure2);
+
+            Dataset dataset2 = new TestableDataset(Lists.newArrayList(
+                    dataPoint("2012", "Netherlands", 23L, 1L),
+                    dataPoint("2012", "Spain", 5L, 2L),
+                    dataPoint("2012", "Iceland", 1L, 3L)
+            ), dataStructure2);
+
+            Dataset resultDataset = new UnionOperation(dataset1, dataset2);
+            softly.assertThat(resultDataset).isNotNull();
+            softly.assertThat(resultDataset.getDataStructure()).isEqualTo(dataStructure2);
+
+            Stream<DataPoint> stream = resultDataset.getData();
+            assertThat(stream).isNotNull();
+
+            assertThat(stream)
+                    .containsExactlyInAnyOrder(
+                            dataPoint("2012", "Belgium", 5L, 1L),
+                            dataPoint("2012", "Greece", 2L, 2L),
+                            dataPoint("2012", "France", 3L, 3L),
+                            dataPoint("2012", "Malta", 7L, 4L),
+                            dataPoint("2012", "Finland", 9L, 5L),
+                            dataPoint("2012", "Switzerland", 12L, 6L),
+                            dataPoint("2012", "Netherlands", 23L, 1L),
+                            dataPoint("2012", "Spain", 5L, 2L),
+                            dataPoint("2012", "Iceland", 1L, 3L)
+                    );
+
+        } finally {
+            softly.assertAll();
+        }
+    }
+
+    @Test
+    public void testDifferentStructures() {
+        doUnionCombos(resultWithDataStructure1First, createDataset1(), createDataset2(), createDataset3());
+        doUnionCombos(resultWithDataStructure1First, createDataset1(), createDataset3(), createDataset2());
+        doUnionCombos(resultWithDataStructure2First, createDataset2(), createDataset1(), createDataset3());
+        doUnionCombos(resultWithDataStructure2First, createDataset2(), createDataset3(), createDataset1());
+        doUnionCombos(resultWithDataStructure3First, createDataset3(), createDataset1(), createDataset2());
+        doUnionCombos(resultWithDataStructure3First, createDataset3(), createDataset2(), createDataset1());
+
+
+        doUnionCombos(new DataPoint[]{
+                dataPoint("2012", "Belgium", 5L, null),
+                dataPoint("2012", "Finland", 9L, null),
+                dataPoint("2012", "France", 3L, null),
+                dataPoint("2012", "Greece", 2L, null),
+                dataPoint("2012", "Iceland", 1L, 3L),
+                dataPoint("2012", "Malta", 7L, null),
+                dataPoint("2012", "Spain", 5L, 2L),
+                dataPoint("2012", "Switzerland", 12L, null),
+                dataPoint("2012", null, 23L, 1L),
+        }, createDataset1(), createDataset2());
+        doUnionCombos(new DataPoint[]{
+                dataPoint("Iceland", "2012", 1L, 3L, null),
+                dataPoint("Iceland", "2013", 1L, null, 3L),
+                dataPoint("Netherlands", "2013", 23L, null, 1L),
+                dataPoint("Spain", "2012", 5L, 2L, null),
+                dataPoint("Spain", null, 5L, null, 2L),
+                dataPoint(null, "2012", 23L, 1L, null),
+        }, createDataset2(), createDataset3());
+    }
+
+    private void doUnionCombos(DataPoint[] expectedResult, TestableDataset... datasets) {
+        SoftAssertions softly = new SoftAssertions();
+        try {
+
+            UnionOperation resultDataset = new UnionOperation(datasets);
+            softly.assertThat(resultDataset).isNotNull();
+
+            softly.assertThat(resultDataset.getDataStructure().getRoles().keySet())
+                    .containsExactly(createExpectedStructure(datasets));
+
+            Stream<DataPoint> stream = resultDataset.getData();
+            assertThat(stream).isNotNull();
+
+            assertThat(stream).containsExactly(expectedResult);
+        } finally {
+            softly.assertAll();
+        }
+    }
+
+    private String[] createExpectedStructure(Dataset... datasets) {
+        // Get base structure
+        List<Entry<String, Component>> baseStructure
+                = new ArrayList<>(datasets[0].getDataStructure().entrySet())
+                .stream().filter(entry -> entry.getValue().getRole() != Component.Role.ATTRIBUTE)
+                .collect(Collectors.toList());
+
+        // Add from rest of children attributes not present in first dataset
+        List<Entry<String, Component>> allAttributes = new ArrayList<>();
+        for (Dataset dataset : datasets) {
+            List<Entry<String, Component>> childAttributes = dataset.getDataStructure().entrySet()
+                    .stream().filter(entry -> entry.getValue().getRole() == Role.ATTRIBUTE)
+                    .filter(entry -> allAttributes.stream()
+                            .noneMatch(attributeEntry -> attributeEntry.getKey().equals(entry.getKey())))
+                    .collect(Collectors.toList());
+            allAttributes.addAll(childAttributes);
+        }
+        allAttributes.sort(Comparator.comparing(Map.Entry::getKey));
+        baseStructure.addAll(allAttributes);
+        return builder().putAll(baseStructure).build().getRoles().keySet().toArray(new String[0]);
+
+    }
+
+    @Test
+    public void testSameIdentifierAndMeasures() {
 
         SoftAssertions softly = new SoftAssertions();
         try {
@@ -78,9 +292,9 @@ public class UnionOperationTest extends RandomizedTest {
             Dataset dataset2 = mock(Dataset.class);
             Dataset dataset3 = mock(Dataset.class);
 
-            when(dataset1.getDataStructure()).thenReturn(dataStructure);
-            when(dataset2.getDataStructure()).thenReturn(dataStructure);
-            when(dataset3.getDataStructure()).thenReturn(dataStructure);
+            when(dataset1.getDataStructure()).thenReturn(dataStructure1);
+            when(dataset2.getDataStructure()).thenReturn(dataStructure1);
+            when(dataset3.getDataStructure()).thenReturn(dataStructure1);
 
             UnionOperation unionOperation = new UnionOperation(dataset1, dataset2, dataset3);
             softly.assertThat(unionOperation).isNotNull();
@@ -188,18 +402,18 @@ public class UnionOperationTest extends RandomizedTest {
                 dataPoint("2012", "Malta", 7L),
                 dataPoint("2012", "Finland", 9L),
                 dataPoint("2012", "Switzerland", 12L)
-        ), dataStructure);
+        ), dataStructure1);
 
         Dataset totalPopulation2 = new TestableDataset(Lists.newArrayList(
                 dataPoint("2012", "Netherlands", 23L),
                 dataPoint("2012", "Spain", 5L),
                 dataPoint("2012", "Iceland", 1L)
-        ), dataStructure);
+        ), dataStructure1);
 
         Dataset resultDataset = new UnionOperation(totalPopulation1, totalPopulation2);
         assertThat(resultDataset).isNotNull();
 
-        assertThat(resultDataset.getDataStructure()).isEqualTo(dataStructure);
+        assertThat(resultDataset.getDataStructure()).isEqualTo(dataStructure1);
 
         Stream<DataPoint> stream = resultDataset.getData();
         assertThat(stream).isNotNull();
@@ -219,7 +433,7 @@ public class UnionOperationTest extends RandomizedTest {
     }
 
     @Test
-    public void testUnionWithOneDifferingComponent() throws Exception {
+    public void testUnionWithOneDifferingComponent() {
 
         // Example 2 of the operator specification.
 
@@ -272,20 +486,20 @@ public class UnionOperationTest extends RandomizedTest {
     }
 
     @Test(expected = VTLRuntimeException.class)
-    public void testUnionWithDuplicate() throws Exception {
+    public void testUnionWithDuplicate() {
 
         Dataset totalPopulation1 = new TestableDataset(Lists.newArrayList(
                 dataPoint("2012", "Greece", 2L),
                 dataPoint("2012", "France", 3L),
                 dataPoint("2012", "Malta", 4L)
-        ), dataStructure);
+        ), dataStructure1);
 
         Dataset totalPopulation2 = new TestableDataset(Lists.newArrayList(
                 dataPoint("2012", "Belgium", 1L),
                 dataPoint("2012", "Greece", 2L),
                 dataPoint("2012", "France", 3L),
                 dataPoint("2012", "Malta", 4L)
-        ), dataStructure);
+        ), dataStructure1);
 
         Dataset resultDataset = new UnionOperation(totalPopulation1, totalPopulation2);
         assertThat(resultDataset).isNotNull();

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,12 @@
                 <repository>
                     <id>releases</id>
                     <name>SSB Nexus Releases</name>
-                    <url>http://kodehus.ssb.no/content/repositories/releases/</url>
+                    <url>https://nexus.ssb.no/repository/maven-releases/</url>
                 </repository>
                 <snapshotRepository>
                     <id>snapshots</id>
                     <name>SSB Snapshot Repository</name>
-                    <url>http://kodehus.ssb.no/content/repositories/snapshots/</url>
+                    <url>https://nexus.ssb.no/repository/maven-snapshots/</url>
                 </snapshotRepository>
             </distributionManagement>
         </profile>


### PR DESCRIPTION
If an attribute is not present in other datasets in a union operations, the attribute will be added to the datapoints from the other dataset(s) with value of null.

Example:
Given the two datasets:

| IC | MC | AC |
| -- | -- | -- |
|1|2|A|

and

| IC | MC |
| -- | -- |
|2|4|

`union(dataset1, dataset2)` will yield the following result:

| IC | MC | AC |
| -- | -- | -- |
|1|2|A|
|2|4|`NULL`|
